### PR TITLE
Implement Tier-B testsuite conformance: boolean schemas (true/false a…

### DIFF
--- a/source/JSONSchema-Core.package/JSONSchemaBooleanFalse.class/class/typeName.st
+++ b/source/JSONSchema-Core.package/JSONSchemaBooleanFalse.class/class/typeName.st
@@ -1,0 +1,3 @@
+instance creation
+typeName
+	^ 'boolean-false'

--- a/source/JSONSchema-Core.package/JSONSchemaBooleanFalse.class/instance/acceptJSONSchema..st
+++ b/source/JSONSchema-Core.package/JSONSchemaBooleanFalse.class/instance/acceptJSONSchema..st
@@ -1,0 +1,4 @@
+visiting
+acceptJSONSchema: aVisitor
+	"a leaf value with no nested schemas to resolve - nothing to visit"
+	^ self

--- a/source/JSONSchema-Core.package/JSONSchemaBooleanFalse.class/instance/validate..st
+++ b/source/JSONSchema-Core.package/JSONSchemaBooleanFalse.class/instance/validate..st
@@ -1,0 +1,3 @@
+validation
+validate: anObject
+	JSONTypeError signal: 'schema is boolean false, no value is valid'

--- a/source/JSONSchema-Core.package/JSONSchemaBooleanFalse.class/instance/validateType..st
+++ b/source/JSONSchema-Core.package/JSONSchemaBooleanFalse.class/instance/validateType..st
@@ -1,0 +1,3 @@
+validation
+validateType: anObject
+	JSONTypeError signal: 'schema is boolean false, no value is valid'

--- a/source/JSONSchema-Core.package/JSONSchemaBooleanFalse.class/properties.json
+++ b/source/JSONSchema-Core.package/JSONSchemaBooleanFalse.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "A schema whose whole value was the JSON literal `false` - per the JSON Schema spec this means \"nothing validates\", the boolean-schema counterpart of JSONSchemaAnyObject (which plays the `true` role - everything validates).",
+	"super" : "JSONSchema",
+	"category" : "JSONSchema-Core-Model",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "JSONSchemaBooleanFalse",
+	"type" : "normal"
+}

--- a/source/JSONSchema-Core.package/JSONSchemaDefinition.class/class/neoJsonMapping..st
+++ b/source/JSONSchema-Core.package/JSONSchemaDefinition.class/class/neoJsonMapping..st
@@ -6,12 +6,48 @@ neoJsonMapping: mapper
 		mapping mapAccessors: #( required description enum ).
 		mapping mapAccessor: #formatString mutator: #formatString: to: #format.
 		(mapping mapAccessor: #properties) valueSchema: #PropertiesDictionary.
-		(mapping mapAccessor: #items) valueSchema: JSONSchemaDefinition.
+		(mapping mapAccessor: #items) valueSchema: #SingleSchema.
 		mapping mapAccessors: #( oneOf anyOf not additionalProperties multipleOf maximum exclusiveMaximum minimum exclusiveMinimum maxLength minLength pattern maxItems minItems uniqueItems maxProperties minProperties  ).
 		(mapping mapAccessor: #allOf) valueSchema: #SchemaList.
 		mapping mapAccessor: #typeString mutator: #typeString: to: #type.
 		 ].
 	mapper for: #PropertiesDictionary customDo: [ :mapping |
-		mapping mapWithValueSchema: JSONSchemaDefinition  ].
+		"Same boolean-tolerant reading as #SchemaList/#SingleSchema below - a property's
+		schema can be a bare true/false, not just an object (e.g. properties:{foo:false})."
+		mapping mapWithValueSchema: JSONSchemaDefinition.
+		mapping reader: [ :jsonReader | | map |
+			map := jsonReader mapClass new.
+			jsonReader parseMapKeysDo: [ :key | | matched value entry |
+				matched := false.
+				value := nil.
+				jsonReader parseConstantDo: [ :v | matched := true. value := v ].
+				entry := (matched and: [ value isKindOf: Boolean ])
+					ifTrue: [ JSONSchemaDefinition new booleanValue: value; yourself ]
+					ifFalse: [ jsonReader nextAs: JSONSchemaDefinition ].
+				map at: key put: entry ].
+			map ] ].
 	mapper for: #SchemaList customDo: [ :mapping |
-		mapping listOfElementSchema: JSONSchemaDefinition. ]
+		"allOf/anyOf/oneOf elements can each be a bare true/false, not just an object
+		(e.g. allOf:[false]) - #listOfElementSchema: keeps the writer, we only replace
+		the reader with a boolean-tolerant version."
+		mapping listOfElementSchema: JSONSchemaDefinition.
+		mapping reader: [ :jsonReader |
+			jsonReader listClass streamContents: [ :stream |
+				jsonReader parseListDo: [ | matched value element |
+					matched := false.
+					value := nil.
+					jsonReader parseConstantDo: [ :v | matched := true. value := v ].
+					element := (matched and: [ value isKindOf: Boolean ])
+						ifTrue: [ JSONSchemaDefinition new booleanValue: value; yourself ]
+						ifFalse: [ jsonReader nextAs: JSONSchemaDefinition ].
+					stream nextPut: element ] ] ] ].
+	mapper for: #SingleSchema customDo: [ :mapping |
+		"A single nested schema slot (currently only #items) that can be a bare
+		true/false, not just an object (e.g. items:false)."
+		mapping reader: [ :jsonReader | | matched value |
+			matched := false.
+			value := nil.
+			jsonReader parseConstantDo: [ :v | matched := true. value := v ].
+			(matched and: [ value isKindOf: Boolean ])
+				ifTrue: [ JSONSchemaDefinition new booleanValue: value; yourself ]
+				ifFalse: [ jsonReader nextAs: JSONSchemaDefinition ] ] ]

--- a/source/JSONSchema-Core.package/JSONSchemaDefinition.class/class/readFrom..st
+++ b/source/JSONSchema-Core.package/JSONSchemaDefinition.class/class/readFrom..st
@@ -1,4 +1,16 @@
 instance creation
 readFrom: stream
-	^ (NeoJSONReader on: stream)
-		nextAs: self
+	"A JSON Schema document is either a JSON object (the common case, read via NeoJSON's
+	regular mapped-object reading) or a bare boolean literal (true = always valid, false =
+	never valid, see JSONSchemaBooleanFalse). #parseConstantDo:'s own return value is not
+	reliable (see the identical pattern in the SchemaList/PropertiesDictionary/SingleSchema
+	readers below) - the side effects on matched/value are what we rely on."
+	| reader matched value |
+	reader := NeoJSONReader on: stream.
+	matched := false.
+	value := nil.
+	reader parseConstantDo: [ :v | matched := true. value := v ].
+	(matched and: [ value isKindOf: Boolean ]) ifTrue: [
+		^ self new booleanValue: value; yourself ].
+	matched ifTrue: [ ^ self error: 'null is not a valid schema' ].
+	^ reader nextAs: self

--- a/source/JSONSchema-Core.package/JSONSchemaDefinition.class/instance/asJSONSchema.st
+++ b/source/JSONSchema-Core.package/JSONSchemaDefinition.class/instance/asJSONSchema.st
@@ -1,5 +1,9 @@
 accessing
 asJSONSchema
 	"^ schemaClass newFromSchemaSpec: self "
+	booleanValue ifNotNil: [
+		^ booleanValue
+			ifTrue: [ JSONSchemaAnyObject new ]
+			ifFalse: [ JSONSchemaBooleanFalse new ] ].
 	^ (self as: (schemaClass ifNil: [ JSONSchemaAnyObject ]))
-		initializeFromDefinition: self 
+		initializeFromDefinition: self

--- a/source/JSONSchema-Core.package/JSONSchemaDefinition.class/instance/booleanValue..st
+++ b/source/JSONSchema-Core.package/JSONSchemaDefinition.class/instance/booleanValue..st
@@ -1,0 +1,3 @@
+accessing
+booleanValue: aBoolean
+	booleanValue := aBoolean

--- a/source/JSONSchema-Core.package/JSONSchemaDefinition.class/instance/booleanValue.st
+++ b/source/JSONSchema-Core.package/JSONSchemaDefinition.class/instance/booleanValue.st
@@ -1,0 +1,3 @@
+accessing
+booleanValue
+	^ booleanValue

--- a/source/JSONSchema-Core.package/JSONSchemaDefinition.class/properties.json
+++ b/source/JSONSchema-Core.package/JSONSchemaDefinition.class/properties.json
@@ -28,7 +28,8 @@
 		"minItems",
 		"maxItems",
 		"minProperties",
-		"maxProperties"
+		"maxProperties",
+		"booleanValue"
 	],
 	"name" : "JSONSchemaDefinition",
 	"type" : "normal"

--- a/source/JSONSchema-Testsuite-Tests.package/JSONSchemaBooleanSchemaFalseTests.class/instance/expectedFailures.st
+++ b/source/JSONSchema-Testsuite-Tests.package/JSONSchemaBooleanSchemaFalseTests.class/instance/expectedFailures.st
@@ -1,3 +1,3 @@
 testing
 expectedFailures
-	^ #(#testStringIsInvalid #testEmptyArrayIsInvalid #testArrayIsInvalid #testNullIsInvalid #testBooleanFalseIsInvalid #testObjectIsInvalid #testEmptyObjectIsInvalid #testNumberIsInvalid #testBooleanTrueIsInvalid)
+	^ #(  )

--- a/source/JSONSchema-Testsuite-Tests.package/JSONSchemaBooleanSchemaTrueTests.class/instance/expectedFailures.st
+++ b/source/JSONSchema-Testsuite-Tests.package/JSONSchemaBooleanSchemaTrueTests.class/instance/expectedFailures.st
@@ -1,3 +1,3 @@
 testing
 expectedFailures
-	^ #(#testBooleanFalseIsValid #testEmptyObjectIsValid #testBooleanTrueIsValid #testObjectIsValid #testArrayIsValid #testNullIsValid #testStringIsValid #testEmptyArrayIsValid #testNumberIsValid)
+	^ #(  )


### PR DESCRIPTION
…s a whole schema)

Discovered while continuing the JSON-Schema-Test-Suite conformance work started in fix-testsuite-tier-a-bugs (see JSONSchema roadmap.md's "Testsuite-Konformität" section).

JSON Schema allows a schema value to be the bare literal `true` (everything validates) or `false` (nothing validates), not just an object with keywords. This was completely unsupported - both the top-level document reader and every nested schema-holding field (properties values, allOf/anyOf/oneOf elements, items) crashed immediately on encountering a boolean token where an object was expected ("{ expected" / "Unexpected boolean constant").

- New `JSONSchemaDefinition>>booleanValue` ivar/accessors mark a definition as representing a bare boolean schema instead of an object with keywords.
- `JSONSchemaDefinition>>asJSONSchema` resolves a boolean-flagged definition to `JSONSchemaAnyObject` (true - the existing "accepts anything" schema) or the new `JSONSchemaBooleanFalse` (false - rejects everything, both `validate:` and `validateType:` unconditionally signal `JSONTypeError`).
- `JSONSchemaDefinition class>>readFrom:` now peeks for a bare boolean literal before falling back to the normal NeoJSON object-mapped read, for top-level schema documents (`JSONSchema fromString: 'true'`).
- The `#PropertiesDictionary`/`#SchemaList` custom NeoJSON mappings (used for `properties` values and `allOf`/`anyOf`/`oneOf` elements respectively) and a new `#SingleSchema` mapping (now used for `items`, replacing a direct `valueSchema: JSONSchemaDefinition`) all get boolean-tolerant custom reader blocks, so a nested schema slot can likewise be `true`/`false` instead of only an object (`items:false`, `properties:{foo:false}`, `allOf:[false]`).

Note on `NeoJSONReader>>parseConstantDo:`: its own return value is not reliable (the underlying `match:do:` has no explicit `^`, so it always returns the reader itself, never the matched value) - every reader above relies on side effects inside the block instead, not the call's return.

Verified via the full JSONSchema-Testsuite-Tests package run (1020 tests): 402 -> 420 passing, 0 failures, 0 errors, no regressions in any other category. Updated the generated `expectedFailures` lists on the two primary boolean-schema test classes (18 tests total) to drop entries that now genuinely pass.