### PR TITLE
Implement Tier-D testsuite conformance: dependencies keyword

### DIFF
--- a/source/JSONSchema-Core/JSONSchemaDefinition.class.st
+++ b/source/JSONSchema-Core/JSONSchemaDefinition.class.st
@@ -29,7 +29,8 @@ Class {
 		'oneOf',
 		'anyOf',
 		'not',
-		'pattern'
+		'pattern',
+		'dependencies'
 	],
 	#category : 'JSONSchema-Core-Model',
 	#package : 'JSONSchema-Core',
@@ -38,7 +39,37 @@ Class {
 
 { #category : 'instance creation' }
 JSONSchemaDefinition class >> fromString: aString [
-	^ self readFrom: aString readStream 
+	^ self readFrom: aString readStream
+]
+
+{ #category : 'instance creation' }
+JSONSchemaDefinition class >> readDependencyValueFrom: jsonReader [
+	"A dependencies-map value is either an array of required property names
+	(property dependency) or a schema (schema dependency, which may itself be a
+	bare true/false). Returns an Array of Strings for the former, a
+	JSONSchemaDefinition for the latter."
+	| matched value names |
+	matched := false.
+	value := nil.
+	jsonReader parseConstantDo: [ :v | matched := true. value := v ].
+	matched ifTrue: [ ^ JSONSchemaDefinition new booleanValue: value; yourself ].
+	(jsonReader matchChar: $[) ifFalse: [ ^ jsonReader nextAs: JSONSchemaDefinition ].
+	names := OrderedCollection new.
+	(jsonReader matchChar: $]) ifFalse: [
+		[ names add: jsonReader parseString.
+		  jsonReader matchChar: $, ] whileTrue.
+		jsonReader expectChar: $] ].
+	^ names asArray
+]
+
+{ #category : 'accessing' }
+JSONSchemaDefinition >> dependencies [
+	^ dependencies
+]
+
+{ #category : 'accessing' }
+JSONSchemaDefinition >> dependencies: aDictionary [
+	dependencies := aDictionary
 ]
 
 { #category : 'accessing' }
@@ -55,6 +86,7 @@ JSONSchemaDefinition class >> neoJsonMapping: mapper [
 		(mapping mapAccessor: #allOf) valueSchema: #SchemaList.
 		(mapping mapAccessor: #anyOf) valueSchema: #SchemaList.
 		(mapping mapAccessor: #oneOf) valueSchema: #SchemaList.
+		(mapping mapAccessor: #dependencies) valueSchema: #DependenciesMap.
 		mapping mapAccessor: #typeString mutator: #typeString: to: #type.
 		 ].
 	mapper for: #PropertiesDictionary customDo: [ :mapping |
@@ -96,7 +128,18 @@ JSONSchemaDefinition class >> neoJsonMapping: mapper [
 			jsonReader parseConstantDo: [ :v | matched := true. value := v ].
 			(matched and: [ value isKindOf: Boolean ])
 				ifTrue: [ JSONSchemaDefinition new booleanValue: value; yourself ]
-				ifFalse: [ jsonReader nextAs: JSONSchemaDefinition ] ] ]
+				ifFalse: [ jsonReader nextAs: JSONSchemaDefinition ] ] ].
+	mapper for: #DependenciesMap customDo: [ :mapping |
+		"The dependencies keyword maps each property name to EITHER an array of
+		required property names (property dependency) OR a schema the whole object
+		must satisfy (schema dependency, possibly a bare true/false). Each value is
+		read polymorphically by JSONSchemaDefinition class>>readDependencyValueFrom:."
+		mapping mapWithValueSchema: JSONSchemaDefinition.
+		mapping reader: [ :jsonReader | | map |
+			map := jsonReader mapClass new.
+			jsonReader parseMapKeysDo: [ :key |
+				map at: key put: (JSONSchemaDefinition readDependencyValueFrom: jsonReader) ].
+			map ] ]
 ]
 
 { #category : 'instance creation' }

--- a/source/JSONSchema-Core/JSONSchemaDependenciesConstraint.class.st
+++ b/source/JSONSchema-Core/JSONSchemaDependenciesConstraint.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : 'JSONSchemaDependenciesConstraint',
+	#superclass : 'JSONSchemaConstraint',
+	#instVars : [
+		'dependencies'
+	],
+	#category : 'JSONSchema-Core-Constraints',
+	#package : 'JSONSchema-Core',
+	#tag : 'Constraints'
+}
+
+{ #category : 'accessing' }
+JSONSchemaDependenciesConstraint >> definitionProperties [
+	^ #( dependencies )
+]
+
+{ #category : 'accessing' }
+JSONSchemaDependenciesConstraint >> dependencies [
+	^ dependencies
+]
+
+{ #category : 'accessing' }
+JSONSchemaDependenciesConstraint >> dependencies: aDictionary [
+	dependencies := aDictionary
+]
+
+{ #category : 'validation' }
+JSONSchemaDependenciesConstraint >> validate [
+	^ dependencies notNil
+]
+
+{ #category : 'validation' }
+JSONSchemaDependenciesConstraint >> validate: aDictionary [
+	"For each present property that carries a dependency: an array-valued dependency
+	requires each named property to be present too (property dependency); a
+	schema-valued dependency requires the whole object to satisfy that schema
+	(schema dependency, possibly a bare true/false)."
+	dependencies keysAndValuesDo: [ :key :dependency |
+		(aDictionary includesKey: key) ifTrue: [
+			dependency isArray
+				ifTrue: [
+					dependency do: [ :requiredKey |
+						(aDictionary includesKey: requiredKey) ifFalse: [
+							JSONConstraintError signal: aDictionary printString, ' is missing property ''', requiredKey, ''' required by dependency on ''', key, '''' ] ] ]
+				ifFalse: [
+					(self resolveVisitor visitSchemaSpec: dependency) validate: aDictionary ] ] ]
+]
+
+{ #category : 'validation' }
+JSONSchemaDependenciesConstraint >> validateType: anObject [
+	"dependencies only constrains object-shaped instances; anything else passes silently."
+	^ anObject isDictionary
+]

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesTests.class.st
@@ -8,7 +8,7 @@ Class {
 
 { #category : 'testing' }
 JSONSchemaDependenciesTests >> expectedFailures [
-	^ #(#testMissingDependency)
+	^ #()
 ]
 
 { #category : 'accessing' }

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesWithBooleanSubschemasTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesWithBooleanSubschemasTests.class.st
@@ -8,7 +8,7 @@ Class {
 
 { #category : 'testing' }
 JSONSchemaDependenciesWithBooleanSubschemasTests >> expectedFailures [
-	^ #(#testObjectWithBothPropertiesIsInvalid #testObjectWithPropertyHavingSchemaFalseIsInvalid)
+	^ #()
 ]
 
 { #category : 'accessing' }

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesWithEscapedCharactersTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesWithEscapedCharactersTests.class.st
@@ -8,7 +8,7 @@ Class {
 
 { #category : 'testing' }
 JSONSchemaDependenciesWithEscapedCharactersTests >> expectedFailures [
-	^ #(#testInvalidObject4 #testInvalidObject1 #testInvalidObject2 #testInvalidObject3)
+	^ #()
 ]
 
 { #category : 'accessing' }

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaMultipleDependenciesSubschemaTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaMultipleDependenciesSubschemaTests.class.st
@@ -8,7 +8,7 @@ Class {
 
 { #category : 'testing' }
 JSONSchemaMultipleDependenciesSubschemaTests >> expectedFailures [
-	^ #(#testWrongType #testWrongTypeOther #testWrongTypeBoth)
+	^ #()
 ]
 
 { #category : 'accessing' }

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaMultipleDependenciesTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaMultipleDependenciesTests.class.st
@@ -8,7 +8,7 @@ Class {
 
 { #category : 'testing' }
 JSONSchemaMultipleDependenciesTests >> expectedFailures [
-	^ #(#testMissingBothDependencies #testMissingDependency #testMissingOtherDependency)
+	^ #()
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
The `dependencies` keyword (Draft-4/6/7 combined form) was not implemented at all — the parser silently ignored the unknown key, making such schemas permissive. That produced the classic "accidentally green" pattern: the 19 valid-value testsuite cases passed by luck while all 13 invalid-value cases failed and were masked as expectedFailures. (The earlier roadmap note that dependencies was "mostly implemented with 13 real bugs" was itself that illusion.)

Now implemented properly:
- JSONSchemaDefinition parses `dependencies` via a new #DependenciesMap custom reader. Each map value is read polymorphically by readDependencyValueFrom:: a JSON array becomes an Array of required property names (property dependency); an object or bare true/false becomes a JSONSchemaDefinition (schema dependency).
- New JSONSchemaDependenciesConstraint enforces both forms on object-shaped instances only (validateType: = isDictionary, so non-objects pass per spec): property dependencies require the named siblings to be present; schema dependencies validate the whole object against the sub-schema (resolved via the shared resolveVisitor, so $ref/boolean sub-schemas work).
- Cleared the now-passing tests from expectedFailures in the six dependencies testsuite classes.

Verified: JSONSchema-Core-Tests 110/110; the six Dependencies testsuite classes 32/32 (13 formerly-broken cases now genuinely pass, no unexpected passes); full JSONSchema-Testsuite-Tests 1018/1020, 0 errors, 0 regressions (remaining 2 = the known Tier-E contains gap). Confirmed by reloading the packages from the on-disk working copy before the final run.