### PR TITLE
Delete empty expectedFailures methods in Dependencies testsuite classes

### DIFF
--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Dependencies'
 }
 
-{ #category : 'testing' }
-JSONSchemaDependenciesTests >> expectedFailures [
-	^ #()
-]
-
 { #category : 'accessing' }
 JSONSchemaDependenciesTests >> schemaString [
 	^ '{"dependencies":{"bar":["foo"]}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesWithBooleanSubschemasTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesWithBooleanSubschemasTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Dependencies'
 }
 
-{ #category : 'testing' }
-JSONSchemaDependenciesWithBooleanSubschemasTests >> expectedFailures [
-	^ #()
-]
-
 { #category : 'accessing' }
 JSONSchemaDependenciesWithBooleanSubschemasTests >> schemaString [
 	^ '{"dependencies":{"foo":true,"bar":false}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesWithEmptyArrayTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesWithEmptyArrayTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Dependencies'
 }
 
-{ #category : 'testing' }
-JSONSchemaDependenciesWithEmptyArrayTests >> expectedFailures [
-	^ #()
-]
-
 { #category : 'accessing' }
 JSONSchemaDependenciesWithEmptyArrayTests >> schemaString [
 	^ '{"dependencies":{"bar":[]}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesWithEscapedCharactersTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaDependenciesWithEscapedCharactersTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Dependencies'
 }
 
-{ #category : 'testing' }
-JSONSchemaDependenciesWithEscapedCharactersTests >> expectedFailures [
-	^ #()
-]
-
 { #category : 'accessing' }
 JSONSchemaDependenciesWithEscapedCharactersTests >> schemaString [
 	^ '{"dependencies":{"foo''bar":{"required":["foo\"bar"]},"foo\"bar":["foo''bar"],"foo\nbar":["foo\rbar"],"foo\tbar":{"minProperties":4}}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaMultipleDependenciesSubschemaTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaMultipleDependenciesSubschemaTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Dependencies'
 }
 
-{ #category : 'testing' }
-JSONSchemaMultipleDependenciesSubschemaTests >> expectedFailures [
-	^ #()
-]
-
 { #category : 'accessing' }
 JSONSchemaMultipleDependenciesSubschemaTests >> schemaString [
 	^ '{"dependencies":{"bar":{"properties":{"foo":{"type":"integer"},"bar":{"type":"integer"}}}}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaMultipleDependenciesTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaMultipleDependenciesTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Dependencies'
 }
 
-{ #category : 'testing' }
-JSONSchemaMultipleDependenciesTests >> expectedFailures [
-	^ #()
-]
-
 { #category : 'accessing' }
 JSONSchemaMultipleDependenciesTests >> schemaString [
 	^ '{"dependencies":{"quux":["foo","bar"]}}'


### PR DESCRIPTION
Follow-up to the Tier-D dependencies implementation: an expectedFailures method that returns an empty array is dead noise (TestCase>>expectedFailures already defaults to #()). Remove the override entirely from the six Dependencies testsuite classes instead of leaving `^ #()`.

No behavior change — all six classes still inherit the empty default. Dependencies 32/32, full testsuite 1018/1020 unchanged.