### PR TITLE
Implement Tier-E testsuite conformance: const keyword

### DIFF
--- a/source/JSONSchema-Core/JSONSchemaConstConstraint.class.st
+++ b/source/JSONSchema-Core/JSONSchemaConstConstraint.class.st
@@ -1,0 +1,39 @@
+Class {
+	#name : 'JSONSchemaConstConstraint',
+	#superclass : 'JSONSchemaConstraint',
+	#instVars : [
+		'const',
+		'constSpecified'
+	],
+	#category : 'JSONSchema-Core-Constraints',
+	#package : 'JSONSchema-Core',
+	#tag : 'Constraints'
+}
+
+{ #category : 'initialization' }
+JSONSchemaConstConstraint >> initializeFromDefinition: aDefinition [
+	"const may be any JSON value including null, so presence is tracked separately
+	from the value (the generic definitionProperties path skips nil values)."
+	constSpecified := aDefinition constSpecified.
+	const := aDefinition const
+]
+
+{ #category : 'validation' }
+JSONSchemaConstConstraint >> validate [
+	^ constSpecified
+]
+
+{ #category : 'validation' }
+JSONSchemaConstConstraint >> validate: anObject [
+	"The instance must be deeply equal to the const value. Smalltalk = already gives
+	the JSON semantics needed: 1 ~= true, 0 ~= false, but 20 = 20.0 (numeric), and
+	arrays/objects compare structurally and order-independently."
+	(const = anObject) ifFalse: [
+		JSONConstraintError signal: anObject printString, ' is not equal to the const value ', const printString ]
+]
+
+{ #category : 'validation' }
+JSONSchemaConstConstraint >> validateType: anObject [
+	"const applies to a value of any type."
+	^ true
+]

--- a/source/JSONSchema-Core/JSONSchemaDefinition.class.st
+++ b/source/JSONSchema-Core/JSONSchemaDefinition.class.st
@@ -30,7 +30,9 @@ Class {
 		'anyOf',
 		'not',
 		'pattern',
-		'dependencies'
+		'dependencies',
+		'const',
+		'constSpecified'
 	],
 	#category : 'JSONSchema-Core-Model',
 	#package : 'JSONSchema-Core',
@@ -63,6 +65,23 @@ JSONSchemaDefinition class >> readDependencyValueFrom: jsonReader [
 ]
 
 { #category : 'accessing' }
+JSONSchemaDefinition >> const [
+	^ const
+]
+
+{ #category : 'accessing' }
+JSONSchemaDefinition >> const: aValue [
+	"const may legitimately be null, so track presence separately from the value."
+	constSpecified := true.
+	const := aValue
+]
+
+{ #category : 'accessing' }
+JSONSchemaDefinition >> constSpecified [
+	^ constSpecified ifNil: [ false ]
+]
+
+{ #category : 'accessing' }
 JSONSchemaDefinition >> dependencies [
 	^ dependencies
 ]
@@ -87,6 +106,7 @@ JSONSchemaDefinition class >> neoJsonMapping: mapper [
 		(mapping mapAccessor: #anyOf) valueSchema: #SchemaList.
 		(mapping mapAccessor: #oneOf) valueSchema: #SchemaList.
 		(mapping mapAccessor: #dependencies) valueSchema: #DependenciesMap.
+		mapping mapAccessor: #const.
 		mapping mapAccessor: #typeString mutator: #typeString: to: #type.
 		 ].
 	mapper for: #PropertiesDictionary customDo: [ :mapping |

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaConstValidationTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaConstValidationTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaConstValidationTests >> expectedFailures [
-	^ #(#testAnotherValueIsInvalid #testAnotherTypeIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaConstValidationTests >> schemaString [
 	^ '{"const":2}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWith0DoesNotMatchOtherZeroLikeTypesTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWith0DoesNotMatchOtherZeroLikeTypesTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaConstWith0DoesNotMatchOtherZeroLikeTypesTests >> expectedFailures [
-	^ #(#testEmptyStringIsInvalid #testEmptyArrayIsInvalid #testFalseIsInvalid #testEmptyObjectIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaConstWith0DoesNotMatchOtherZeroLikeTypesTests >> schemaString [
 	^ '{"const":0}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWith1DoesNotMatchTrueTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWith1DoesNotMatchTrueTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaConstWith1DoesNotMatchTrueTests >> expectedFailures [
-	^ #(#testTrueIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaConstWith1DoesNotMatchTrueTests >> schemaString [
 	^ '{"const":1}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWith20MatchesIntegerAndFloatTypesTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWith20MatchesIntegerAndFloatTypesTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaConstWith20MatchesIntegerAndFloatTypesTests >> expectedFailures [
-	^ #(#testInteger2IsInvalid #testFloat20IsInvalid #testFloat200001IsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaConstWith20MatchesIntegerAndFloatTypesTests >> schemaString [
 	^ '{"const":-2.0}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWithArrayTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWithArrayTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaConstWithArrayTests >> expectedFailures [
-	^ #(#testAnotherArrayItemIsInvalid #testArrayWithAdditionalItemsIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaConstWithArrayTests >> schemaString [
 	^ '{"const":[{"foo":"bar"}]}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWithFalseDoesNotMatch0Tests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWithFalseDoesNotMatch0Tests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaConstWithFalseDoesNotMatch0Tests >> expectedFailures [
-	^ #(#testFloatZeroIsInvalid #testIntegerZeroIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaConstWithFalseDoesNotMatch0Tests >> schemaString [
 	^ '{"const":false}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWithNullTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWithNullTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaConstWithNullTests >> expectedFailures [
-	^ #(#testNotNullIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaConstWithNullTests >> schemaString [
 	^ '{"const":null}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWithObjectTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWithObjectTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaConstWithObjectTests >> expectedFailures [
-	^ #(#testAnotherObjectIsInvalid #testAnotherTypeIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaConstWithObjectTests >> schemaString [
 	^ '{"const":{"foo":"bar","baz":"bax"}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWithTrueDoesNotMatch1Tests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaConstWithTrueDoesNotMatch1Tests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaConstWithTrueDoesNotMatch1Tests >> expectedFailures [
-	^ #(#testFloatOneIsInvalid #testIntegerOneIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaConstWithTrueDoesNotMatch1Tests >> schemaString [
 	^ '{"const":true}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaFloatAndIntegersAreEqualUpTo64BitRepresentationLimitsTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaFloatAndIntegersAreEqualUpTo64BitRepresentationLimitsTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaFloatAndIntegersAreEqualUpTo64BitRepresentationLimitsTests >> expectedFailures [
-	^ #(#testFloatMinusOneIsInvalid #testIntegerMinusOneIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaFloatAndIntegersAreEqualUpTo64BitRepresentationLimitsTests >> schemaString [
 	^ '{"const":9007199254740992}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaNulCharactersInStringsTests1.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaNulCharactersInStringsTests1.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Const'
 }
 
-{ #category : 'testing' }
-JSONSchemaNulCharactersInStringsTests1 >> expectedFailures [
-	^ #(#testDoNotMatchStringLackingNul)
-]
-
 { #category : 'accessing' }
 JSONSchemaNulCharactersInStringsTests1 >> schemaString [
 	^ '{"const":"hello\u0000there"}'


### PR DESCRIPTION
`const` (exact-value equality) was unimplemented — the parser ignored the key, making such schemas permissive (the "accidentally green" pattern: valid cases passed by luck, invalid cases failed and were masked as expectedFailures).

- JSONSchemaDefinition parses `const` as a raw JSON value. Because const may legitimately be null, presence is tracked with a separate constSpecified flag (the generic constraint-from-definition path skips nil values, and a plain nil ivar can't distinguish "const: null" from "const absent").
- New JSONSchemaConstConstraint requires the instance to be deeply equal to the const value. Smalltalk `=` already yields the JSON semantics the suite demands: 1 ~= true and 0 ~= false (distinct classes), but 20 = 20.0 (numeric), and arrays/objects compare structurally and order-independently.
- Removed the now-passing tests from expectedFailures across all const-using testsuite classes (nine Const* classes plus FloatAndIntegers...Limits and NulCharactersInStrings1); per convention an empty expectedFailures method is deleted rather than left returning #().

Verified (after reloading both packages from the on-disk working copy): JSONSchema-Core-Tests 110/110; all const cases green; full JSONSchema-Testsuite-Tests 1018/1020, 0 errors, 0 regressions (remaining 2 = the known contains gap). The contains+const and if+boolean-schema classes still fail as expected (those keywords are not yet implemented).