### PR TITLE
Implement Tier-E testsuite conformance: union types (type as array)

### DIFF
--- a/source/JSONSchema-Core/JSONSchemaDefinition.class.st
+++ b/source/JSONSchema-Core/JSONSchemaDefinition.class.st
@@ -32,7 +32,8 @@ Class {
 		'pattern',
 		'dependencies',
 		'const',
-		'constSpecified'
+		'constSpecified',
+		'typeArray'
 	],
 	#category : 'JSONSchema-Core-Model',
 	#package : 'JSONSchema-Core',
@@ -494,8 +495,18 @@ JSONSchemaDefinition >> title: anObject [
 ]
 
 { #category : 'accessing' }
-JSONSchemaDefinition >> typeString: aString [ 
-	schemaClass := JSONSchema typeNamed: aString
+JSONSchemaDefinition >> typeArray [
+	^ typeArray
+]
+
+{ #category : 'accessing' }
+JSONSchemaDefinition >> typeString: aStringOrArray [
+	"type may be a single type name (sets the schema class, single-type path) or an
+	array of names (a union type, kept for JSONSchemaTypeUnionConstraint - the schema
+	class stays open/JSONSchemaAnyObject and the constraint does the type check)."
+	aStringOrArray isString
+		ifTrue: [ schemaClass := JSONSchema typeNamed: aStringOrArray ]
+		ifFalse: [ typeArray := aStringOrArray ]
 ]
 
 { #category : 'accessing' }

--- a/source/JSONSchema-Core/JSONSchemaTypeUnionConstraint.class.st
+++ b/source/JSONSchema-Core/JSONSchemaTypeUnionConstraint.class.st
@@ -1,0 +1,58 @@
+Class {
+	#name : 'JSONSchemaTypeUnionConstraint',
+	#superclass : 'JSONSchemaConstraint',
+	#instVars : [
+		'typeArray'
+	],
+	#category : 'JSONSchema-Core-Constraints',
+	#package : 'JSONSchema-Core',
+	#tag : 'Constraints'
+}
+
+{ #category : 'accessing' }
+JSONSchemaTypeUnionConstraint >> definitionProperties [
+	^ #( typeArray )
+]
+
+{ #category : 'accessing' }
+JSONSchemaTypeUnionConstraint >> typeArray [
+	^ typeArray
+]
+
+{ #category : 'accessing' }
+JSONSchemaTypeUnionConstraint >> typeArray: aCollection [
+	typeArray := aCollection
+]
+
+{ #category : 'validation' }
+JSONSchemaTypeUnionConstraint >> validate [
+	^ typeArray notNil
+]
+
+{ #category : 'validation' }
+JSONSchemaTypeUnionConstraint >> validate: anObject [
+	"The instance must match at least one of the listed JSON types."
+	(typeArray anySatisfy: [ :typeName | self value: anObject matchesTypeNamed: typeName ])
+		ifFalse: [
+			JSONTypeError signal: anObject printString, ' is none of the allowed types: ', (',' join: typeArray) ]
+]
+
+{ #category : 'validation' }
+JSONSchemaTypeUnionConstraint >> validateType: anObject [
+	"a union type applies to a value of any type."
+	^ true
+]
+
+{ #category : 'validation' }
+JSONSchemaTypeUnionConstraint >> value: anObject matchesTypeNamed: aTypeName [
+	"Top-level JSON type-category test - a union type only constrains the type tag,
+	not any nested structure (unlike a single type:array/object schema)."
+	aTypeName = 'null' ifTrue: [ ^ anObject isNil ].
+	aTypeName = 'boolean' ifTrue: [ ^ anObject isKindOf: Boolean ].
+	aTypeName = 'integer' ifTrue: [ ^ anObject isKindOf: Integer ].
+	aTypeName = 'number' ifTrue: [ ^ anObject isKindOf: Number ].
+	aTypeName = 'string' ifTrue: [ ^ anObject isString ].
+	aTypeName = 'array' ifTrue: [ ^ anObject isArray ].
+	aTypeName = 'object' ifTrue: [ ^ anObject isDictionary ].
+	^ false
+]

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaMultipleTypesCanBeSpecifiedInAnArrayTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaMultipleTypesCanBeSpecifiedInAnArrayTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Type'
 }
 
-{ #category : 'testing' }
-JSONSchemaMultipleTypesCanBeSpecifiedInAnArrayTests >> expectedFailures [
-	^ #(#testNullIsInvalid #testABooleanIsInvalid #testAnIntegerIsValid #testAFloatIsInvalid #testAStringIsValid #testAnObjectIsInvalid #testAnArrayIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaMultipleTypesCanBeSpecifiedInAnArrayTests >> schemaString [
 	^ '{"type":["integer","string"]}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaNotMultipleTypesTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaNotMultipleTypesTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Not'
 }
 
-{ #category : 'testing' }
-JSONSchemaNotMultipleTypesTests >> expectedFailures [
-	^ #(#testMismatch #testOtherMismatch #testValid)
-]
-
 { #category : 'accessing' }
 JSONSchemaNotMultipleTypesTests >> schemaString [
 	^ '{"not":{"type":["integer","boolean"]}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaTypeArrayObjectOrNullTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaTypeArrayObjectOrNullTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Type'
 }
 
-{ #category : 'testing' }
-JSONSchemaTypeArrayObjectOrNullTests >> expectedFailures [
-	^ #(#testStringIsInvalid #testObjectIsValid #testNullIsValid #testArrayIsValid #testNumberIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaTypeArrayObjectOrNullTests >> schemaString [
 	^ '{"type":["array","object","null"]}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaTypeArrayOrObjectTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaTypeArrayOrObjectTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Type'
 }
 
-{ #category : 'testing' }
-JSONSchemaTypeArrayOrObjectTests >> expectedFailures [
-	^ #(#testStringIsInvalid #testObjectIsValid #testNullIsInvalid #testArrayIsValid #testNumberIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaTypeArrayOrObjectTests >> schemaString [
 	^ '{"type":["array","object"]}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaTypeAsArrayWithOneItemTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaTypeAsArrayWithOneItemTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Type'
 }
 
-{ #category : 'testing' }
-JSONSchemaTypeAsArrayWithOneItemTests >> expectedFailures [
-	^ #(#testStringIsValid #testNumberIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaTypeAsArrayWithOneItemTests >> schemaString [
 	^ '{"type":["string"]}'


### PR DESCRIPTION
`type` as an array of names (e.g. {"type":["integer","string"]}) was
unsupported — typeString: assumed a single string and JSONSchema class>>
typeNamed: raised "type with name #(...) not found", so every test in the five union-type classes errored at parse time (all marked expectedFailures).

- JSONSchemaDefinition>>typeString: now branches: a String keeps the existing single-type path (sets the schema class); an Array is stored as typeArray and the schema class stays open (JSONSchemaAnyObject).
- New JSONSchemaTypeUnionConstraint validates that the instance matches at least one of the listed JSON types, using a direct top-level type-category test (a union type constrains only the type tag, not nested structure, so reusing the per-type validateType: — which descends into items/properties — would be wrong and also crashes on uninitialised array/object schemas). Categories follow the existing single-type semantics: integer excludes floats and booleans, number includes integers, null is its own type.
- Removed the now-passing expectedFailures methods from the five union-type testsuite classes (including the union-inside-not case).

Based on master (dependencies + const already merged); independent of the contains branch. Verified: the five union classes are fully green; no regressions in JSONSchema-Core-Tests or the rest of the testsuite.