### PR TITLE
Implement Tier-E testsuite conformance: propertyNames keyword

### DIFF
--- a/source/JSONSchema-Core/JSONSchemaDefinition.class.st
+++ b/source/JSONSchema-Core/JSONSchemaDefinition.class.st
@@ -32,7 +32,8 @@ Class {
 		'pattern',
 		'dependencies',
 		'const',
-		'constSpecified'
+		'constSpecified',
+		'propertyNames'
 	],
 	#category : 'JSONSchema-Core-Model',
 	#package : 'JSONSchema-Core',
@@ -92,6 +93,16 @@ JSONSchemaDefinition >> dependencies: aDictionary [
 ]
 
 { #category : 'accessing' }
+JSONSchemaDefinition >> propertyNames [
+	^ propertyNames
+]
+
+{ #category : 'accessing' }
+JSONSchemaDefinition >> propertyNames: aDefinition [
+	propertyNames := aDefinition
+]
+
+{ #category : 'accessing' }
 JSONSchemaDefinition class >> neoJsonMapping: mapper [
 	mapper for: self do: [ :mapping |
 		mapping mapAccessor: #reference to: '$ref'.
@@ -106,6 +117,7 @@ JSONSchemaDefinition class >> neoJsonMapping: mapper [
 		(mapping mapAccessor: #anyOf) valueSchema: #SchemaList.
 		(mapping mapAccessor: #oneOf) valueSchema: #SchemaList.
 		(mapping mapAccessor: #dependencies) valueSchema: #DependenciesMap.
+		(mapping mapAccessor: #propertyNames) valueSchema: #SingleSchema.
 		mapping mapAccessor: #const.
 		mapping mapAccessor: #typeString mutator: #typeString: to: #type.
 		 ].

--- a/source/JSONSchema-Core/JSONSchemaPropertyNamesConstraint.class.st
+++ b/source/JSONSchema-Core/JSONSchemaPropertyNamesConstraint.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : 'JSONSchemaPropertyNamesConstraint',
+	#superclass : 'JSONSchemaConstraint',
+	#instVars : [
+		'propertyNames'
+	],
+	#category : 'JSONSchema-Core-Constraints',
+	#package : 'JSONSchema-Core',
+	#tag : 'Constraints'
+}
+
+{ #category : 'accessing' }
+JSONSchemaPropertyNamesConstraint >> definitionProperties [
+	^ #( propertyNames )
+]
+
+{ #category : 'accessing' }
+JSONSchemaPropertyNamesConstraint >> propertyNames [
+	^ propertyNames
+]
+
+{ #category : 'accessing' }
+JSONSchemaPropertyNamesConstraint >> propertyNames: aDefinition [
+	propertyNames := aDefinition
+]
+
+{ #category : 'validation' }
+JSONSchemaPropertyNamesConstraint >> validate [
+	^ propertyNames notNil
+]
+
+{ #category : 'validation' }
+JSONSchemaPropertyNamesConstraint >> validate: aDictionary [
+	"Every property name (a string key) must itself validate against the
+	propertyNames sub-schema."
+	| resolved |
+	resolved := self resolveVisitor visitSchemaSpec: propertyNames.
+	aDictionary keysDo: [ :key | resolved validate: key ]
+]
+
+{ #category : 'validation' }
+JSONSchemaPropertyNamesConstraint >> validateType: anObject [
+	"propertyNames only constrains objects; anything else passes silently."
+	^ anObject isDictionary
+]

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaPropertyNamesValidationTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaPropertyNamesValidationTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'PropertyNames'
 }
 
-{ #category : 'testing' }
-JSONSchemaPropertyNamesValidationTests >> expectedFailures [
-	^ #(#testSomePropertyNamesInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaPropertyNamesValidationTests >> schemaString [
 	^ '{"propertyNames":{"maxLength":3}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaPropertyNamesWithBooleanSchemaFalseTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaPropertyNamesWithBooleanSchemaFalseTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'PropertyNames'
 }
 
-{ #category : 'testing' }
-JSONSchemaPropertyNamesWithBooleanSchemaFalseTests >> expectedFailures [
-	^ #(#testObjectWithAnyPropertiesIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaPropertyNamesWithBooleanSchemaFalseTests >> schemaString [
 	^ '{"propertyNames":false}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaPropertyNamesWithBooleanSchemaTrueTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaPropertyNamesWithBooleanSchemaTrueTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'PropertyNames'
 }
 
-{ #category : 'testing' }
-JSONSchemaPropertyNamesWithBooleanSchemaTrueTests >> expectedFailures [
-	^ #()
-]
-
 { #category : 'accessing' }
 JSONSchemaPropertyNamesWithBooleanSchemaTrueTests >> schemaString [
 	^ '{"propertyNames":true}'


### PR DESCRIPTION
`propertyNames` (a schema applied to each object property name) was unimplemented — the parser ignored the key, so the invalid-key cases failed (masked as expectedFailures) while valid ones passed by luck.

- JSONSchemaDefinition parses `propertyNames` as a single nested schema slot (#SingleSchema, so a bare true/false is accepted too).
- New JSONSchemaPropertyNamesConstraint applies only to objects (validateType: = isDictionary, so non-objects pass per spec) and validates each property name (a string key) against the sub-schema, resolved via the shared resolveVisitor. An empty object passes (no keys); propertyNames:false rejects any object that has a property.
- Removed the now-passing/empty expectedFailures methods from the three propertyNames testsuite classes.

Based on master; independent of the contains and union-type branches (each adds one ivar to JSONSchemaDefinition, so the second/third to merge shows a trivial ivar-list conflict — keep all). Verified: the propertyNames classes are fully green; JSONSchema-Core-Tests 110/110; no regressions.