### PR TITLE
Implement Tier-F testsuite conformance: tuple items + additionalItems

### DIFF
--- a/source/JSONSchema-Core-Tests/JSONSchemaDefinitionTests.class.st
+++ b/source/JSONSchema-Core-Tests/JSONSchemaDefinitionTests.class.st
@@ -35,14 +35,17 @@ JSONSchemaDefinitionTests >> testArrayMultipleItemsDefinition [
 
 { #category : 'tests' }
 JSONSchemaDefinitionTests >> testArrayMultipleItemsDefinitionDifferentSizes [
+	"Per JSON-Schema spec a tuple (items as an array of schemas) applies positionally;
+	an instance shorter than the tuple is valid (the missing positions are simply
+	unconstrained), and extra items are governed by additionalItems. So a 2-element
+	array against a 3-schema tuple validates as long as the present positions match."
 	| schema |
 	schema := JSONSchemaArray new
 		items: { JSONSchema integer . JSONSchema string . JSONSchema boolean }.
-	
-	self 
-		should: [ 
-		 schema validate: { 3 . #foo } ]
-		raise: JSONTypeError 
+
+	self shouldnt: [ schema validate: { 3 . 'foo' } ] raise: JSONTypeError.
+	"a wrong type at a present position still fails"
+	self should: [ schema validate: { 'bar' . 'foo' } ] raise: JSONTypeError
 ]
 
 { #category : 'tests' }

--- a/source/JSONSchema-Core/JSONSchemaArray.class.st
+++ b/source/JSONSchema-Core/JSONSchemaArray.class.st
@@ -81,14 +81,18 @@ JSONSchemaArray >> schemaProperties [
 
 { #category : 'validating' }
 JSONSchemaArray >> validateType: aCollection [
+	"Array type check plus positional element type-checking for the DSL path
+	(JSONSchemaArray built directly, without constraints). Spec-compliant tuples:
+	a single-schema items applies to every element; an array (tuple) applies
+	positionally, and a shorter or longer instance is allowed here (additionalItems
+	is enforced by JSONSchemaSingleItemSchemaConstraint on parsed schemas)."
 	aCollection isArray ifFalse: [
 		JSONTypeError signal: aCollection printString, ' is not an array' ].
+	items ifNil: [ ^ self ].
 	items isCollection
 		ifTrue: [
-			(aCollection size = items size) ifFalse: [
-				JSONTypeError signal: aCollection asString, ' has different size than schema' ].
-			aCollection withIndexDo: [:item :idx |
-				(items at: idx) validateType: item ] ]
+			aCollection withIndexDo: [ :item :idx |
+				idx <= items size ifTrue: [ (items at: idx) validateType: item ] ] ]
 		ifFalse: [
 			aCollection do: [ :each |
 				items validateType: each ] ]

--- a/source/JSONSchema-Core/JSONSchemaDefinition.class.st
+++ b/source/JSONSchema-Core/JSONSchemaDefinition.class.st
@@ -39,7 +39,8 @@ Class {
 		'patternProperties',
 		'ifSchema',
 		'thenSchema',
-		'elseSchema'
+		'elseSchema',
+		'additionalItems'
 	],
 	#category : 'JSONSchema-Core-Model',
 	#package : 'JSONSchema-Core',
@@ -69,6 +70,30 @@ JSONSchemaDefinition class >> readDependencyValueFrom: jsonReader [
 		  jsonReader matchChar: $, ] whileTrue.
 		jsonReader expectChar: $] ].
 	^ names asArray
+]
+
+{ #category : 'instance creation' }
+JSONSchemaDefinition class >> readItemsValueFrom: jsonReader [
+	"items is either a single schema (object or bare true/false) or an array of
+	schemas (tuple/positional validation). Returns a JSONSchemaDefinition for the
+	former, an Array of JSONSchemaDefinition for the latter."
+	| matched value |
+	matched := false.
+	value := nil.
+	jsonReader parseConstantDo: [ :v | matched := true. value := v ].
+	matched ifTrue: [ ^ JSONSchemaDefinition new booleanValue: value; yourself ].
+	(jsonReader matchChar: $[) ifFalse: [ ^ jsonReader nextAs: JSONSchemaDefinition ].
+	^ Array streamContents: [ :stream |
+		(jsonReader matchChar: $]) ifFalse: [
+			[ | m v elem |
+			  m := false. v := nil.
+			  jsonReader parseConstantDo: [ :x | m := true. v := x ].
+			  elem := (m and: [ v isKindOf: Boolean ])
+				ifTrue: [ JSONSchemaDefinition new booleanValue: v; yourself ]
+				ifFalse: [ jsonReader nextAs: JSONSchemaDefinition ].
+			  stream nextPut: elem.
+			  jsonReader matchChar: $, ] whileTrue.
+			jsonReader expectChar: $] ] ]
 ]
 
 { #category : 'accessing' }
@@ -126,7 +151,8 @@ JSONSchemaDefinition class >> neoJsonMapping: mapper [
 		mapping mapAccessors: #( required description enum pattern ).
 		mapping mapAccessor: #formatString mutator: #formatString: to: #format.
 		(mapping mapAccessor: #properties) valueSchema: #PropertiesDictionary.
-		(mapping mapAccessor: #items) valueSchema: #SingleSchema.
+		(mapping mapAccessor: #items) valueSchema: #ItemsSchema.
+		(mapping mapAccessor: #additionalItems) valueSchema: #SingleSchema.
 		(mapping mapAccessor: #not) valueSchema: #SingleSchema.
 		(mapping mapAccessor: #additionalProperties) valueSchema: #SingleSchema.
 		mapping mapAccessors: #( multipleOf maximum exclusiveMaximum minimum exclusiveMinimum maxLength minLength maxItems minItems uniqueItems maxProperties minProperties  ).
@@ -193,7 +219,13 @@ JSONSchemaDefinition class >> neoJsonMapping: mapper [
 			map := jsonReader mapClass new.
 			jsonReader parseMapKeysDo: [ :key |
 				map at: key put: (JSONSchemaDefinition readDependencyValueFrom: jsonReader) ].
-			map ] ]
+			map ] ].
+	mapper for: #ItemsSchema customDo: [ :mapping |
+		"items is either a single schema (object or bare true/false) or an array of
+		schemas (tuple/positional validation). Read polymorphically by
+		JSONSchemaDefinition class>>readItemsValueFrom:."
+		mapping reader: [ :jsonReader |
+			JSONSchemaDefinition readItemsValueFrom: jsonReader ] ]
 ]
 
 { #category : 'instance creation' }
@@ -379,6 +411,18 @@ JSONSchemaDefinition >> initialize [
 { #category : 'testing' }
 JSONSchemaDefinition >> isReference [
 	^ reference notNil
+]
+
+{ #category : 'accessing' }
+JSONSchemaDefinition >> additionalItems [
+	^ additionalItems
+]
+
+{ #category : 'accessing' }
+JSONSchemaDefinition >> additionalItems: anObject [
+	"Mapped via #SingleSchema (a bare true/false becomes a booleanValue definition);
+	asJSONSchema resolves it. nil = absent = extra items allowed."
+	additionalItems := anObject ifNotNil: [ anObject asJSONSchema ]
 ]
 
 { #category : 'accessing' }

--- a/source/JSONSchema-Core/JSONSchemaSingleItemSchemaConstraint.class.st
+++ b/source/JSONSchema-Core/JSONSchemaSingleItemSchemaConstraint.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'JSONSchemaSingleItemSchemaConstraint',
 	#superclass : 'JSONSchemaConstraint',
 	#instVars : [
-		'items'
+		'items',
+		'additionalItems'
 	],
 	#category : 'JSONSchema-Core-Constraints',
 	#package : 'JSONSchema-Core',
@@ -19,9 +20,12 @@ JSONSchemaSingleItemSchemaConstraint >> items: aDefinition [
 	items := aDefinition
 ]
 
-{ #category : 'accessing' }
-JSONSchemaSingleItemSchemaConstraint >> definitionProperties [
-	^ #( items )
+{ #category : 'initialization' }
+JSONSchemaSingleItemSchemaConstraint >> initializeFromDefinition: aDefinition [
+	"items may be a single schema or an array of schemas (tuple); additionalItems
+	governs positions beyond a tuple."
+	items := aDefinition items.
+	additionalItems := aDefinition additionalItems
 ]
 
 { #category : 'validation' }
@@ -31,9 +35,24 @@ JSONSchemaSingleItemSchemaConstraint >> validate [
 
 { #category : 'validation' }
 JSONSchemaSingleItemSchemaConstraint >> validate: anArray [
-	| resolved |
-	resolved := self resolveVisitor visitSchemaSpec: items.
-	anArray do: [ :each | resolved validate: each ]
+	items isCollection
+		ifTrue: [ self validateTuple: anArray ]
+		ifFalse: [ | resolved |
+			resolved := self resolveVisitor visitSchemaSpec: items.
+			anArray do: [ :each | resolved validate: each ] ]
+]
+
+{ #category : 'validation' }
+JSONSchemaSingleItemSchemaConstraint >> validateTuple: anArray [
+	"Positional validation: element i against items[i]. Elements beyond the tuple are
+	validated against additionalItems when it is an actual schema (nil/absent = allowed;
+	additionalItems:false resolves to JSONSchemaBooleanFalse = no extra items)."
+	| resolvedTuple |
+	resolvedTuple := items collect: [ :def | self resolveVisitor visitSchemaSpec: def ].
+	anArray withIndexDo: [ :each :i |
+		i <= resolvedTuple size
+			ifTrue: [ (resolvedTuple at: i) validate: each ]
+			ifFalse: [ (additionalItems isKindOf: JSONSchema) ifTrue: [ additionalItems validate: each ] ] ]
 ]
 
 { #category : 'validation' }

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaAdditionalItemsAreAllowedByDefaultTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaAdditionalItemsAreAllowedByDefaultTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'AdditionalItems'
 }
 
-{ #category : 'testing' }
-JSONSchemaAdditionalItemsAreAllowedByDefaultTests >> expectedFailures [
-	^ #(#testOnlyTheFirstItemIsValidated)
-]
-
 { #category : 'accessing' }
 JSONSchemaAdditionalItemsAreAllowedByDefaultTests >> schemaString [
 	^ '{"items":[{"type":"integer"}]}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaAdditionalItemsAsSchemaTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaAdditionalItemsAsSchemaTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'AdditionalItems'
 }
 
-{ #category : 'testing' }
-JSONSchemaAdditionalItemsAsSchemaTests >> expectedFailures [
-	^ #(#testAdditionalItemsMatchSchema #testAdditionalItemsDoNotMatchSchema)
-]
-
 { #category : 'accessing' }
 JSONSchemaAdditionalItemsAsSchemaTests >> schemaString [
 	^ '{"items":[{}],"additionalItems":{"type":"integer"}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaAdditionalItemsShouldNotLookInApplicatorsInvalidCaseTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaAdditionalItemsShouldNotLookInApplicatorsInvalidCaseTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'AdditionalItems'
 }
 
-{ #category : 'testing' }
-JSONSchemaAdditionalItemsShouldNotLookInApplicatorsInvalidCaseTests >> expectedFailures [
-	^ #(#testItemsDefinedInAllOfAreNotExamined)
-]
-
 { #category : 'accessing' }
 JSONSchemaAdditionalItemsShouldNotLookInApplicatorsInvalidCaseTests >> schemaString [
 	^ '{"allOf":[{"items":[{"type":"integer"},{"type":"string"}]}],"items":[{"type":"integer"}],"additionalItems":{"type":"boolean"}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaAdditionalItemsShouldNotLookInApplicatorsValidCaseTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaAdditionalItemsShouldNotLookInApplicatorsValidCaseTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'AdditionalItems'
 }
 
-{ #category : 'testing' }
-JSONSchemaAdditionalItemsShouldNotLookInApplicatorsValidCaseTests >> expectedFailures [
-	^ #(#testItemsDefinedInAllOfAreNotExamined)
-]
-
 { #category : 'accessing' }
 JSONSchemaAdditionalItemsShouldNotLookInApplicatorsValidCaseTests >> schemaString [
 	^ '{"allOf":[{"items":[{"type":"integer"}]}],"additionalItems":{"type":"boolean"}}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaAnArrayOfSchemasForItemsTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaAnArrayOfSchemasForItemsTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Items'
 }
 
-{ #category : 'testing' }
-JSONSchemaAnArrayOfSchemasForItemsTests >> expectedFailures [
-	^ #(#testIncompleteArrayOfItems #testWrongTypes #testJavaScriptPseudoArrayIsValid #testEmptyArray #testArrayWithAdditionalItems #testCorrectTypes)
-]
-
 { #category : 'accessing' }
 JSONSchemaAnArrayOfSchemasForItemsTests >> schemaString [
 	^ '{"items":[{"type":"integer"},{"type":"string"}]}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaArrayOfItemsWithNoAdditionalItemsTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaArrayOfItemsWithNoAdditionalItemsTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'AdditionalItems'
 }
 
-{ #category : 'testing' }
-JSONSchemaArrayOfItemsWithNoAdditionalItemsTests >> expectedFailures [
-	^ #(#testEqualNumberOfItemsPresent #testEmptyArray #testFewerNumberOfItemsPresent1 #testFewerNumberOfItemsPresent2 #testAdditionalItemsAreNotPermitted)
-]
-
 { #category : 'accessing' }
 JSONSchemaArrayOfItemsWithNoAdditionalItemsTests >> schemaString [
 	^ '{"items":[{},{},{}],"additionalItems":false}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaItemsAndSubitemsTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaItemsAndSubitemsTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Items'
 }
 
-{ #category : 'testing' }
-JSONSchemaItemsAndSubitemsTests >> expectedFailures [
-	^ #(#testValidItems #testWrongItem #testFewerItemsIsValid #testTooManyItems #testTooManySubItems #testWrongSubItem)
-]
-
 { #category : 'accessing' }
 JSONSchemaItemsAndSubitemsTests >> schemaString [
 	^ '{"definitions":{"item":{"additionalItems":false,"items":[{"$ref":"#/definitions/sub-item"},{"$ref":"#/definitions/sub-item"}],"type":"array"},"sub-item":{"required":["foo"],"type":"object"}},"additionalItems":false,"items":[{"$ref":"#/definitions/item"},{"$ref":"#/definitions/item"},{"$ref":"#/definitions/item"}],"type":"array"}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaItemsWithBooleanSchemasTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaItemsWithBooleanSchemasTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Items'
 }
 
-{ #category : 'testing' }
-JSONSchemaItemsWithBooleanSchemasTests >> expectedFailures [
-	^ #(#testArrayWithOneItemIsValid #testArrayWithTwoItemsIsInvalid #testEmptyArrayIsValid)
-]
-
 { #category : 'accessing' }
 JSONSchemaItemsWithBooleanSchemasTests >> schemaString [
 	^ '{"items":[true,false]}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaUniqueItemsFalseWithAnArrayOfItemsAndAdditionalItemsFalseTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaUniqueItemsFalseWithAnArrayOfItemsAndAdditionalItemsFalseTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'UniqueItems'
 }
 
-{ #category : 'testing' }
-JSONSchemaUniqueItemsFalseWithAnArrayOfItemsAndAdditionalItemsFalseTests >> expectedFailures [
-	^ #(#testTrueFalseFromItemsArrayIsValid #testTrueTrueFromItemsArrayIsValid #testFalseTrueFromItemsArrayIsValid #testFalseFalseFromItemsArrayIsValid #testExtraItemsAreInvalidEvenIfUnique)
-]
-
 { #category : 'accessing' }
 JSONSchemaUniqueItemsFalseWithAnArrayOfItemsAndAdditionalItemsFalseTests >> schemaString [
 	^ '{"items":[{"type":"boolean"},{"type":"boolean"}],"uniqueItems":false,"additionalItems":false}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaUniqueItemsFalseWithAnArrayOfItemsTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaUniqueItemsFalseWithAnArrayOfItemsTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'UniqueItems'
 }
 
-{ #category : 'testing' }
-JSONSchemaUniqueItemsFalseWithAnArrayOfItemsTests >> expectedFailures [
-	^ #(#testNonUniqueArrayExtendedFromTrueFalseIsValid #testUniqueArrayExtendedFromFalseTrueIsValid #testFalseFalseFromItemsArrayIsValid #testFalseTrueFromItemsArrayIsValid #testUniqueArrayExtendedFromTrueFalseIsValid #testTrueTrueFromItemsArrayIsValid #testTrueFalseFromItemsArrayIsValid #testNonUniqueArrayExtendedFromFalseTrueIsValid)
-]
-
 { #category : 'accessing' }
 JSONSchemaUniqueItemsFalseWithAnArrayOfItemsTests >> schemaString [
 	^ '{"items":[{"type":"boolean"},{"type":"boolean"}],"uniqueItems":false}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaUniqueItemsWithAnArrayOfItemsAndAdditionalItemsFalseTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaUniqueItemsWithAnArrayOfItemsAndAdditionalItemsFalseTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'UniqueItems'
 }
 
-{ #category : 'testing' }
-JSONSchemaUniqueItemsWithAnArrayOfItemsAndAdditionalItemsFalseTests >> expectedFailures [
-	^ #(#testTrueFalseFromItemsArrayIsValid #testExtraItemsAreInvalidEvenIfUnique #testFalseTrueFromItemsArrayIsValid #testFalseFalseFromItemsArrayIsNotValid #testTrueTrueFromItemsArrayIsNotValid)
-]
-
 { #category : 'accessing' }
 JSONSchemaUniqueItemsWithAnArrayOfItemsAndAdditionalItemsFalseTests >> schemaString [
 	^ '{"items":[{"type":"boolean"},{"type":"boolean"}],"uniqueItems":true,"additionalItems":false}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaUniqueItemsWithAnArrayOfItemsTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaUniqueItemsWithAnArrayOfItemsTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'UniqueItems'
 }
 
-{ #category : 'testing' }
-JSONSchemaUniqueItemsWithAnArrayOfItemsTests >> expectedFailures [
-	^ #(#testFalseTrueFromItemsArrayIsValid #testFalseFalseFromItemsArrayIsNotValid #testNonUniqueArrayExtendedFromTrueFalseIsNotValid #testTrueTrueFromItemsArrayIsNotValid #testTrueFalseFromItemsArrayIsValid #testUniqueArrayExtendedFromFalseTrueIsValid #testUniqueArrayExtendedFromTrueFalseIsValid #testNonUniqueArrayExtendedFromFalseTrueIsNotValid)
-]
-
 { #category : 'accessing' }
 JSONSchemaUniqueItemsWithAnArrayOfItemsTests >> schemaString [
 	^ '{"items":[{"type":"boolean"},{"type":"boolean"}],"uniqueItems":true}'


### PR DESCRIPTION
`items` as an array of schemas (positional/tuple validation) and `additionalItems` were unimplemented; the old tuple path also required an exact size match, which is not spec-compliant.

- JSONSchemaDefinition parses `items` polymorphically (readItemsValueFrom:): a single schema (object or bare true/false) OR an array of schemas (tuple). `additionalItems` parses via #SingleSchema (object schema, or true/false → JSONSchemaAnyObject / JSONSchemaBooleanFalse).
- JSONSchemaSingleItemSchemaConstraint now handles both: single-schema items (every element) and tuple items (element i against items[i]); elements beyond the tuple are validated against additionalItems when it is a real schema (absent = allowed, false = no extra items). Sub-schemas resolve via the shared resolveVisitor ($ref/boolean work).
- JSONSchemaArray>>validateType: (the DSL path, no constraints) is now positional and spec-compliant: no exact-size requirement, missing/extra positions allowed. Updated the one Core test that encoded the old exact-size behaviour.
- Removed the now-passing expectedFailures methods from the 12 affected tuple-items / additionalItems / uniqueItems-with-tuple classes.

Based on fresh master. Verified: all Items/additionalItems/uniqueItems testsuite classes green (109/109, excl. the murky-image contains case which is fine on master), JSONSchema-Core-Tests 110/110, no regressions.