### PR TITLE
Read the 2020-12 $defs keyword (alongside draft-04 definitions)

### DIFF
--- a/source/JSONSchema-Core/JSONSchemaDocument.class.st
+++ b/source/JSONSchema-Core/JSONSchemaDocument.class.st
@@ -14,7 +14,9 @@ Class {
 JSONSchemaDocument class >> neoJsonMapping: mapper [
 	super neoJsonMapping: mapper.
 	mapper for: self do: [ :mapping |
-		(mapping mapInstVar: #definitions) valueSchema: #SchemaMap ].
+		(mapping mapInstVar: #definitions) valueSchema: #SchemaMap.
+		"JSON Schema 2020-12 renamed 'definitions' to '$defs'; read both into the same ivar so a $ref like #/$defs/x resolves."
+		(mapping mapInstVar: #definitions to: '$defs') valueSchema: #SchemaMap ].
 		
 	mapper for: #SchemaMap customDo: [ :mapping |
 		mapping mapWithValueSchema: JSONSchemaDefinition ].


### PR DESCRIPTION
JSONSchemaDocument only mapped the draft-04 'definitions' key, so a $ref like #/$defs/x failed with 'only integers should be used as indices' (definitions ivar was nil). Map $defs into the same ivar so 2020-12 documents resolve local refs — this lets the OpenAPI 3.1 meta-schema build. Core-Tests 110/110; draft-04 'definitions' resolution unaffected.