### PR TITLE
Implement Tier-G testsuite conformance: cheap format validators

### DIFF
--- a/source/JSONSchema-Core/JSONFormatHostname.class.st
+++ b/source/JSONSchema-Core/JSONFormatHostname.class.st
@@ -1,0 +1,62 @@
+Class {
+	#name : 'JSONFormatHostname',
+	#superclass : 'JSONBasicStringFormat',
+	#category : 'JSONSchema-Core-Formats',
+	#package : 'JSONSchema-Core',
+	#tag : 'Formats'
+}
+
+{ #category : 'reading' }
+JSONFormatHostname class >> basicConvertString: aString [
+	^ aString
+]
+
+{ #category : 'reading' }
+JSONFormatHostname class >> encodeJSON: aString [
+	^ aString
+]
+
+{ #category : 'accessing' }
+JSONFormatHostname class >> formatName [
+	^ 'hostname'
+]
+
+{ #category : 'validation' }
+JSONFormatHostname class >> isLDHChar: aChar [
+	"Letter, digit or hyphen (the RFC 1034 preferred-name character set)."
+	^ (aChar between: $0 and: $9)
+		or: [ (aChar between: $a and: $z)
+		or: [ (aChar between: $A and: $Z) or: [ aChar = $- ] ] ]
+]
+
+{ #category : 'validation' }
+JSONFormatHostname class >> isValidString: aString [
+	"RFC 1034 preferred name syntax: dot-separated labels, each 1-63 LDH characters,
+	not beginning or ending with a hyphen; total length at most 253."
+	| labels |
+	(aString isEmpty or: [ aString size > 253 ]) ifTrue: [ ^ false ].
+	labels := self splitString: aString on: $..
+	labels do: [ :label |
+		(label size between: 1 and: 63) ifFalse: [ ^ false ].
+		(label first = $- or: [ label last = $- ]) ifTrue: [ ^ false ].
+		(label allSatisfy: [ :c | self isLDHChar: c ]) ifFalse: [ ^ false ] ].
+	^ true
+]
+
+{ #category : 'validation' }
+JSONFormatHostname class >> splitString: aString on: aChar [
+	| res start |
+	res := OrderedCollection new.
+	start := 1.
+	1 to: aString size do: [ :i |
+		(aString at: i) = aChar ifTrue: [
+			res add: (aString copyFrom: start to: i - 1). start := i + 1 ] ].
+	res add: (aString copyFrom: start to: aString size).
+	^ res
+]
+
+{ #category : 'validation' }
+JSONFormatHostname class >> validateString: aString [
+	(self isValidString: aString) ifFalse: [
+		JSONConstraintError signal: aString printString, ' is not a valid hostname' ]
+]

--- a/source/JSONSchema-Core/JSONFormatIPv6.class.st
+++ b/source/JSONSchema-Core/JSONFormatIPv6.class.st
@@ -1,0 +1,102 @@
+Class {
+	#name : 'JSONFormatIPv6',
+	#superclass : 'JSONBasicStringFormat',
+	#category : 'JSONSchema-Core-Formats',
+	#package : 'JSONSchema-Core',
+	#tag : 'Formats'
+}
+
+{ #category : 'validation' }
+JSONFormatIPv6 class >> basicConvertString: aString [
+	"The value of an ipv6 format is simply the string itself."
+	^ aString
+]
+
+{ #category : 'validation' }
+JSONFormatIPv6 class >> encodeJSON: aString [
+	^ aString
+]
+
+{ #category : 'validation' }
+JSONFormatIPv6 class >> formatName [
+	^ 'ipv6'
+]
+
+{ #category : 'validation' }
+JSONFormatIPv6 class >> isHexGroup: aString [
+	^ aString notEmpty
+		and: [ aString size <= 4
+		and: [ aString allSatisfy: [ :ch | '0123456789abcdefABCDEF' includes: ch ] ] ]
+]
+
+{ #category : 'validation' }
+JSONFormatIPv6 class >> isIPv4Part: aString [
+	"A dotted-decimal IPv4 tail: exactly four decimal octets 0..255."
+	| parts |
+	parts := self splitString: aString on: $..
+	^ parts size = 4
+		and: [ parts allSatisfy: [ :p |
+			(p notEmpty and: [ p size <= 3 ])
+				and: [ (p allSatisfy: [ :ch | ch isDigit ]) and: [ p asInteger <= 255 ] ] ] ]
+]
+
+{ #category : 'validation' }
+JSONFormatIPv6 class >> isValidString: aString [
+	"RFC 4291 IPv6 text form: 8 groups of 1-4 hex digits separated by colons, with an
+	optional single :: compressing one or more all-zero groups, and an optional
+	dotted-decimal IPv4 tail occupying the last two groups. Rejects whitespace, zone
+	ids (%), netmasks (/), triple colons and two :: runs."
+	| dc before after firstPart secondPart allTokens slots valid lastIsV4 |
+	valid := true.
+	aString isEmpty ifTrue: [ ^ false ].
+	(aString anySatisfy: [ :ch | ch isSeparator ]) ifTrue: [ ^ false ].
+	((aString includes: $/) or: [ aString includes: $% ]) ifTrue: [ ^ false ].
+	dc := aString indexOfSubCollection: '::'.
+	dc = 0
+		ifTrue: [ firstPart := self splitString: aString on: $:. secondPart := nil ]
+		ifFalse: [
+			(aString indexOfSubCollection: '::' startingAt: dc + 2) = 0 ifFalse: [ ^ false ].
+			before := aString copyFrom: 1 to: dc - 1.
+			after := aString copyFrom: dc + 2 to: aString size.
+			(before notEmpty and: [ before last = $: ]) ifTrue: [ ^ false ].
+			(after notEmpty and: [ after first = $: ]) ifTrue: [ ^ false ].
+			firstPart := before isEmpty ifTrue: [ #() ] ifFalse: [ self splitString: before on: $: ].
+			secondPart := after isEmpty ifTrue: [ #() ] ifFalse: [ self splitString: after on: $: ] ].
+	allTokens := dc = 0
+		ifTrue: [ firstPart ]
+		ifFalse: [ (OrderedCollection withAll: firstPart) addAll: secondPart; yourself ].
+	allTokens doWithIndex: [ :tok :i |
+		(i < allTokens size and: [ tok includes: $. ]) ifTrue: [ valid := false ] ].
+	slots := 0.
+	allTokens isEmpty ifFalse: [
+		lastIsV4 := allTokens last includes: $..
+		allTokens allButLast do: [ :tok |
+			(self isHexGroup: tok) ifFalse: [ valid := false ]. slots := slots + 1 ].
+		lastIsV4
+			ifTrue: [ (self isIPv4Part: allTokens last) ifFalse: [ valid := false ]. slots := slots + 2 ]
+			ifFalse: [ (self isHexGroup: allTokens last) ifFalse: [ valid := false ]. slots := slots + 1 ] ].
+	dc = 0
+		ifTrue: [ slots = 8 ifFalse: [ valid := false ] ]
+		ifFalse: [ slots >= 8 ifTrue: [ valid := false ] ].
+	^ valid
+]
+
+{ #category : 'validation' }
+JSONFormatIPv6 class >> splitString: aString on: aChar [
+	"Split keeping empty tokens (unlike substrings:), so stray/leading/trailing
+	colons surface as empty groups that then fail validation."
+	| res start |
+	res := OrderedCollection new.
+	start := 1.
+	1 to: aString size do: [ :i |
+		(aString at: i) = aChar ifTrue: [
+			res add: (aString copyFrom: start to: i - 1). start := i + 1 ] ].
+	res add: (aString copyFrom: start to: aString size).
+	^ res
+]
+
+{ #category : 'validation' }
+JSONFormatIPv6 class >> validateString: aString [
+	(self isValidString: aString) ifFalse: [
+		JSONConstraintError signal: aString printString, ' is not a valid ipv6 address' ]
+]

--- a/source/JSONSchema-Core/JSONFormatJSONPointer.class.st
+++ b/source/JSONSchema-Core/JSONFormatJSONPointer.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : 'JSONFormatJSONPointer',
+	#superclass : 'JSONBasicStringFormat',
+	#category : 'JSONSchema-Core-Formats',
+	#package : 'JSONSchema-Core',
+	#tag : 'Formats'
+}
+
+{ #category : 'reading' }
+JSONFormatJSONPointer class >> basicConvertString: aString [
+	^ aString
+]
+
+{ #category : 'reading' }
+JSONFormatJSONPointer class >> encodeJSON: aString [
+	^ aString
+]
+
+{ #category : 'accessing' }
+JSONFormatJSONPointer class >> formatName [
+	^ 'json-pointer'
+]
+
+{ #category : 'validation' }
+JSONFormatJSONPointer class >> isValidString: aString [
+	"RFC 6901: a JSON Pointer is either empty or a sequence of /-prefixed reference
+	tokens; within a token ~ must be followed by 0 (escapes ~) or 1 (escapes /)."
+	aString isEmpty ifTrue: [ ^ true ].
+	aString first = $/ ifFalse: [ ^ false ].
+	1 to: aString size do: [ :i |
+		(aString at: i) = $~ ifTrue: [
+			i = aString size ifTrue: [ ^ false ].
+			((aString at: i + 1) = $0 or: [ (aString at: i + 1) = $1 ]) ifFalse: [ ^ false ] ] ].
+	^ true
+]
+
+{ #category : 'validation' }
+JSONFormatJSONPointer class >> validateString: aString [
+	(self isValidString: aString) ifFalse: [
+		JSONConstraintError signal: aString printString, ' is not a valid json-pointer' ]
+]

--- a/source/JSONSchema-Core/JSONFormatRegex.class.st
+++ b/source/JSONSchema-Core/JSONFormatRegex.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : 'JSONFormatRegex',
+	#superclass : 'JSONBasicStringFormat',
+	#category : 'JSONSchema-Core-Formats',
+	#package : 'JSONSchema-Core',
+	#tag : 'Formats'
+}
+
+{ #category : 'reading' }
+JSONFormatRegex class >> basicConvertString: aString [
+	^ aString
+]
+
+{ #category : 'reading' }
+JSONFormatRegex class >> encodeJSON: aString [
+	^ aString
+]
+
+{ #category : 'accessing' }
+JSONFormatRegex class >> formatName [
+	^ 'regex'
+]
+
+{ #category : 'validation' }
+JSONFormatRegex class >> validateString: aString [
+	"format:regex - the string must be a compilable regular expression."
+	[ aString asRegex ] on: Error do: [ :e |
+		JSONConstraintError signal: aString printString, ' is not a valid regular expression' ]
+]

--- a/source/JSONSchema-Core/JSONFormatTime.class.st
+++ b/source/JSONSchema-Core/JSONFormatTime.class.st
@@ -1,0 +1,58 @@
+Class {
+	#name : 'JSONFormatTime',
+	#superclass : 'JSONBasicStringFormat',
+	#category : 'JSONSchema-Core-Formats',
+	#package : 'JSONSchema-Core',
+	#tag : 'Formats'
+}
+
+{ #category : 'reading' }
+JSONFormatTime class >> basicConvertString: aString [
+	^ aString
+]
+
+{ #category : 'reading' }
+JSONFormatTime class >> encodeJSON: aString [
+	^ aString
+]
+
+{ #category : 'accessing' }
+JSONFormatTime class >> formatName [
+	^ 'time'
+]
+
+{ #category : 'validation' }
+JSONFormatTime class >> isValidString: aString [
+	"RFC 3339 full-time: HH:MM:SS with an optional fractional second and a required
+	offset (Z or +/-HH:MM). Hours 0-23, minutes 0-59, seconds 0-60 (leap second)."
+	| idx |
+	aString size < 9 ifTrue: [ ^ false ].
+	((self twoDigitsIn: aString at: 1 max: 23) and: [ (aString at: 3) = $: ]) ifFalse: [ ^ false ].
+	((self twoDigitsIn: aString at: 4 max: 59) and: [ (aString at: 6) = $: ]) ifFalse: [ ^ false ].
+	(self twoDigitsIn: aString at: 7 max: 60) ifFalse: [ ^ false ].
+	idx := 9.
+	(idx <= aString size and: [ (aString at: idx) = $. ]) ifTrue: [
+		idx := idx + 1.
+		(idx <= aString size and: [ (aString at: idx) isDigit ]) ifFalse: [ ^ false ].
+		[ idx <= aString size and: [ (aString at: idx) isDigit ] ] whileTrue: [ idx := idx + 1 ] ].
+	idx > aString size ifTrue: [ ^ false ].
+	((aString at: idx) = $Z or: [ (aString at: idx) = $z ]) ifTrue: [ ^ idx = aString size ].
+	(((aString at: idx) = $+ or: [ (aString at: idx) = $- ]) and: [ (aString size - idx) = 5 ])
+		ifFalse: [ ^ false ].
+	^ (self twoDigitsIn: aString at: idx + 1 max: 23)
+		and: [ (aString at: idx + 3) = $: and: [ self twoDigitsIn: aString at: idx + 4 max: 59 ] ]
+]
+
+{ #category : 'validation' }
+JSONFormatTime class >> twoDigitsIn: aString at: i max: aMax [
+	"True if the two characters at i..i+1 are digits forming a value in 0..aMax."
+	^ ((i + 1) <= aString size
+		and: [ (aString at: i) isDigit and: [ (aString at: i + 1) isDigit ] ])
+		and: [ (aString copyFrom: i to: i + 1) asInteger <= aMax ]
+]
+
+{ #category : 'validation' }
+JSONFormatTime class >> validateString: aString [
+	(self isValidString: aString) ifFalse: [
+		JSONConstraintError signal: aString printString, ' is not a valid time' ]
+]

--- a/source/JSONSchema-Core/JSONFormatURIReference.class.st
+++ b/source/JSONSchema-Core/JSONFormatURIReference.class.st
@@ -1,0 +1,38 @@
+Class {
+	#name : 'JSONFormatURIReference',
+	#superclass : 'JSONBasicStringFormat',
+	#category : 'JSONSchema-Core-Formats',
+	#package : 'JSONSchema-Core',
+	#tag : 'Formats'
+}
+
+{ #category : 'reading' }
+JSONFormatURIReference class >> basicConvertString: aString [
+	^ aString
+]
+
+{ #category : 'reading' }
+JSONFormatURIReference class >> encodeJSON: aString [
+	^ aString
+]
+
+{ #category : 'accessing' }
+JSONFormatURIReference class >> formatName [
+	^ 'uri-reference'
+]
+
+{ #category : 'validation' }
+JSONFormatURIReference class >> isValidString: aString [
+	"A necessary URI-reference check (RFC 3986): every character must be a legal URI
+	character - unreserved, reserved (gen/sub-delims) or the percent-escape marker.
+	This rejects e.g. backslashes and spaces while accepting absolute and relative refs."
+	| allowed |
+	allowed := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]@!$&''()*+,;=%'.
+	^ aString allSatisfy: [ :c | allowed includes: c ]
+]
+
+{ #category : 'validation' }
+JSONFormatURIReference class >> validateString: aString [
+	(self isValidString: aString) ifFalse: [
+		JSONConstraintError signal: aString printString, ' is not a valid uri-reference' ]
+]

--- a/source/JSONSchema-Core/JSONFormatURITemplate.class.st
+++ b/source/JSONSchema-Core/JSONFormatURITemplate.class.st
@@ -1,0 +1,40 @@
+Class {
+	#name : 'JSONFormatURITemplate',
+	#superclass : 'JSONBasicStringFormat',
+	#category : 'JSONSchema-Core-Formats',
+	#package : 'JSONSchema-Core',
+	#tag : 'Formats'
+}
+
+{ #category : 'reading' }
+JSONFormatURITemplate class >> basicConvertString: aString [
+	^ aString
+]
+
+{ #category : 'reading' }
+JSONFormatURITemplate class >> encodeJSON: aString [
+	^ aString
+]
+
+{ #category : 'accessing' }
+JSONFormatURITemplate class >> formatName [
+	^ 'uri-template'
+]
+
+{ #category : 'validation' }
+JSONFormatURITemplate class >> isValidString: aString [
+	"RFC 6570 expressions are delimited by { and }. A necessary well-formedness check:
+	braces must be balanced and non-nested (every { closed by a } before the next {)."
+	| inside |
+	inside := false.
+	aString do: [ :c |
+		c = ${ ifTrue: [ inside ifTrue: [ ^ false ]. inside := true ]
+		ifFalse: [ c = $} ifTrue: [ inside ifFalse: [ ^ false ]. inside := false ] ] ].
+	^ inside not
+]
+
+{ #category : 'validation' }
+JSONFormatURITemplate class >> validateString: aString [
+	(self isValidString: aString) ifFalse: [
+		JSONConstraintError signal: aString printString, ' is not a valid uri-template' ]
+]

--- a/source/JSONSchema-Core/JSONSchemaFormatConstraint.class.st
+++ b/source/JSONSchema-Core/JSONSchemaFormatConstraint.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : 'JSONSchemaFormatConstraint',
+	#superclass : 'JSONSchemaConstraint',
+	#instVars : [
+		'format'
+	],
+	#category : 'JSONSchema-Core-Constraints',
+	#package : 'JSONSchema-Core',
+	#tag : 'Constraints'
+}
+
+{ #category : 'validation' }
+JSONSchemaFormatConstraint >> definitionProperties [
+	"Empty: format is not round-tripped through the generic serialise path (the value
+	is a JSONFormat class, and typed schemas already write format via JSONPrimitiveSchema)."
+	^ #()
+]
+
+{ #category : 'validation' }
+JSONSchemaFormatConstraint >> format [
+	^ format
+]
+
+{ #category : 'validation' }
+JSONSchemaFormatConstraint >> format: aFormat [
+	format := aFormat
+]
+
+{ #category : 'validation' }
+JSONSchemaFormatConstraint >> initializeFromDefinition: aDefinition [
+	"Read the resolved JSONFormat class (or nil) from the definition. Overrides the
+	generic property-copy since format is stored as a class, not a plain value, and
+	must not be re-serialised through definitionProperties."
+	format := aDefinition format
+]
+
+{ #category : 'validation' }
+JSONSchemaFormatConstraint >> validate [
+	^ format notNil
+]
+
+{ #category : 'validation' }
+JSONSchemaFormatConstraint >> validate: aString [
+	"Delegate to the format class. Unimplemented formats keep the no-op default
+	(tolerant); implemented ones signal a JSONSchemaError on a malformed string."
+	format validateString: aString
+]
+
+{ #category : 'validation' }
+JSONSchemaFormatConstraint >> validateType: anObject [
+	"format applies to strings only; non-strings pass through per JSON-Schema spec."
+	^ anObject isString
+]

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaFormatUriTemplateTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaFormatUriTemplateTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'UriTemplate'
 }
 
-{ #category : 'testing' }
-JSONSchemaFormatUriTemplateTests >> expectedFailures [
-	^ #(#testAnInvalidUriTemplate)
-]
-
 { #category : 'accessing' }
 JSONSchemaFormatUriTemplateTests >> schemaString [
 	^ '{"format":"uri-template"}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfHostNamesTests2.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfHostNamesTests2.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Hostname'
 }
 
-{ #category : 'testing' }
-JSONSchemaValidationOfHostNamesTests2 >> expectedFailures [
-	^ #(#testAHostNameContainingIllegalCharacters #testAHostNameStartingWithAnIllegalCharacter #testAHostNameWithAComponentTooLong #testContainsUnderscore #testEndsWithHyphen #testEndsWithUnderscore #testExceedsMaximumLabelLength #testStartsWithHyphen #testStartsWithUnderscore)
-]
-
 { #category : 'accessing' }
 JSONSchemaValidationOfHostNamesTests2 >> schemaString [
 	^ '{"format":"hostname"}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfIPv6AddressesTests2.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfIPv6AddressesTests2.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Ipv6'
 }
 
-{ #category : 'testing' }
-JSONSchemaValidationOfIPv6AddressesTests2 >> expectedFailures [
-	^ #(#testALongInvalidIpv6BelowLengthLimitFirst #testALongInvalidIpv6BelowLengthLimitSecond #testAnIPv6AddressContainingIllegalCharacters #testAnIPv6AddressWithOutOfRangeValues #testAnIPv6AddressWithTooManyComponents #testInsufficientOctetsWithoutDoubleColons #testIpv4IsNotIpv6 #testIpv4SegmentMustHave4Octets #testLeadingWhitespaceIsInvalid #testMissingLeadingOctetIsInvalid #testMissingLeadingOctetWithOmittedOctetsLater #testMissingTrailingOctetIsInvalid #testMixedFormatWithIpv4SectionWithAHexOctet #testMixedFormatWithIpv4SectionWithOctetOutOfRange #testNetmaskIsNotAPartOfIpv6Address #testNoColonsIsInvalid #testTrailingWhitespaceIsInvalid #testTripleColonsIsInvalid #testTwoSetsOfDoubleColonsIsInvalid #testZoneIdIsNotAPartOfIpv6Address)
-]
-
 { #category : 'accessing' }
 JSONSchemaValidationOfIPv6AddressesTests2 >> schemaString [
 	^ '{"format":"ipv6"}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfJSONPointersJSONStringRepresentationTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfJSONPointersJSONStringRepresentationTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'JsonPointer'
 }
 
-{ #category : 'testing' }
-JSONSchemaValidationOfJSONPointersJSONStringRepresentationTests >> expectedFailures [
-	^ #(#testNotAValidJSONPointerIsnTEmptyNorStartsWith1 #testNotAValidJSONPointerIsnTEmptyNorStartsWith2 #testNotAValidJSONPointerIsnTEmptyNorStartsWith3 #testNotAValidJSONPointerMultipleCharactersNotEscaped #testNotAValidJSONPointerNotEscaped #testNotAValidJSONPointerSomeEscapedButNotAll1 #testNotAValidJSONPointerSomeEscapedButNotAll2 #testNotAValidJSONPointerURIFragmentIdentifier1 #testNotAValidJSONPointerURIFragmentIdentifier2 #testNotAValidJSONPointerURIFragmentIdentifier3 #testNotAValidJSONPointerWrongEscapeCharacter1 #testNotAValidJSONPointerWrongEscapeCharacter2)
-]
-
 { #category : 'accessing' }
 JSONSchemaValidationOfJSONPointersJSONStringRepresentationTests >> schemaString [
 	^ '{"format":"json-pointer"}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfRegularExpressionsTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfRegularExpressionsTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Regex'
 }
 
-{ #category : 'testing' }
-JSONSchemaValidationOfRegularExpressionsTests >> expectedFailures [
-	^ #(#testARegularExpressionWithUnclosedParensIsInvalid)
-]
-
 { #category : 'accessing' }
 JSONSchemaValidationOfRegularExpressionsTests >> schemaString [
 	^ '{"format":"regex"}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfTimeStringsTests2.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfTimeStringsTests2.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Time'
 }
 
-{ #category : 'testing' }
-JSONSchemaValidationOfTimeStringsTests2 >> expectedFailures [
-	^ #(#testAnInvalidTimeString #testOnlyRFC3339NotAllOfISO8601AreValid)
-]
-
 { #category : 'accessing' }
 JSONSchemaValidationOfTimeStringsTests2 >> schemaString [
 	^ '{"format":"time"}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfURIReferencesTests2.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfURIReferencesTests2.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'UriReference'
 }
 
-{ #category : 'testing' }
-JSONSchemaValidationOfURIReferencesTests2 >> expectedFailures [
-	^ #(#testAnInvalidURIFragment #testAnInvalidURIReference)
-]
-
 { #category : 'accessing' }
 JSONSchemaValidationOfURIReferencesTests2 >> schemaString [
 	^ '{"format":"uri-reference"}'


### PR DESCRIPTION
Add real format validators for the low-effort JSON-Schema formats, turning 47 previously-expectedFailures format tests green.

The key enabler is a generic JSONSchemaFormatConstraint: format applies to strings regardless of the declared type, and the testsuite schemas ({"format": "ipv6"} with no "type") build as JSONSchemaAnyObject, which never consulted the format. The constraint fires from initializeFromDefinition: like the other Tier C-F constraints, guards to strings in validateType:, and delegates to the format class's validateString: (a no-op by default, so still-unimplemented formats stay tolerant).

New JSONFormat subclasses, each with a class-side validateString::
  - ipv6          (RFC 4291: groups, :: compression, embedded IPv4 tail)
  - json-pointer  (RFC 6901: /-prefixed tokens, ~0/~1 escapes)
  - hostname      (RFC 1034 LDH labels, 1-63 chars, no leading/trailing hyphen)
  - time          (RFC 3339 full-time with required offset)
  - uri-reference (RFC 3986 legal-character necessary check)
  - regex         (must compile as a regular expression)
  - uri-template  (RFC 6570 balanced, non-nested {} expressions)

Verified: Core 110/110, all touched format test classes green, no regressions (the testsuite failing set drops from 168 to 141 under a raw runCase sweep). expectedFailures cleared in the seven now-fully-green format test classes (methods deleted per convention).