### PR TITLE
Implement Tier-G testsuite conformance: iri/uri/iri-reference/relativ…

### DIFF
--- a/source/JSONSchema-Core/JSONFormatIRI.class.st
+++ b/source/JSONSchema-Core/JSONFormatIRI.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : 'JSONFormatIRI',
+	#superclass : 'JSONFormatURI',
+	#category : 'JSONSchema-Core-Formats',
+	#package : 'JSONSchema-Core',
+	#tag : 'Formats'
+}
+
+{ #category : 'accessing' }
+JSONFormatIRI class >> formatName [
+	^ 'iri'
+]
+
+{ #category : 'validation' }
+JSONFormatIRI class >> validateString: aString [
+	(self isValidURIString: aString allowUnicode: true) ifFalse: [
+		JSONConstraintError signal: aString printString, ' is not a valid iri' ]
+]

--- a/source/JSONSchema-Core/JSONFormatIRIReference.class.st
+++ b/source/JSONSchema-Core/JSONFormatIRIReference.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : 'JSONFormatIRIReference',
+	#superclass : 'JSONBasicStringFormat',
+	#category : 'JSONSchema-Core-Formats',
+	#package : 'JSONSchema-Core',
+	#tag : 'Formats'
+}
+
+{ #category : 'reading' }
+JSONFormatIRIReference class >> basicConvertString: aString [
+	^ aString
+]
+
+{ #category : 'reading' }
+JSONFormatIRIReference class >> encodeJSON: aString [
+	^ aString
+]
+
+{ #category : 'accessing' }
+JSONFormatIRIReference class >> formatName [
+	^ 'iri-reference'
+]
+
+{ #category : 'validation' }
+JSONFormatIRIReference class >> isValidString: aString [
+	"An IRI reference is any sequence of legal IRI characters - the RFC 3986 repertoire
+	plus non-ASCII ucschar. Notably rejects backslashes, spaces and other controls."
+	| legal |
+	legal := 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]@!$&''()*+,;=%'.
+	^ aString allSatisfy: [ :c | (legal includes: c) or: [ c asInteger > 127 ] ]
+]
+
+{ #category : 'validation' }
+JSONFormatIRIReference class >> validateString: aString [
+	(self isValidString: aString) ifFalse: [
+		JSONConstraintError signal: aString printString, ' is not a valid iri-reference' ]
+]

--- a/source/JSONSchema-Core/JSONFormatRelativeJSONPointer.class.st
+++ b/source/JSONSchema-Core/JSONFormatRelativeJSONPointer.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : 'JSONFormatRelativeJSONPointer',
+	#superclass : 'JSONBasicStringFormat',
+	#category : 'JSONSchema-Core-Formats',
+	#package : 'JSONSchema-Core',
+	#tag : 'Formats'
+}
+
+{ #category : 'reading' }
+JSONFormatRelativeJSONPointer class >> basicConvertString: aString [
+	^ aString
+]
+
+{ #category : 'reading' }
+JSONFormatRelativeJSONPointer class >> encodeJSON: aString [
+	^ aString
+]
+
+{ #category : 'accessing' }
+JSONFormatRelativeJSONPointer class >> formatName [
+	^ 'relative-json-pointer'
+]
+
+{ #category : 'validation' }
+JSONFormatRelativeJSONPointer class >> isValidString: aString [
+	"A non-negative integer prefix (no leading zeros) followed by either # or a JSON
+	Pointer (RFC 6901). The prefix counts how many levels to ascend."
+	| idx intPart rest |
+	(aString isEmpty or: [ aString first isDigit not ]) ifTrue: [ ^ false ].
+	idx := 1.
+	[ idx <= aString size and: [ (aString at: idx) isDigit ] ] whileTrue: [ idx := idx + 1 ].
+	intPart := aString copyFrom: 1 to: idx - 1.
+	(intPart size > 1 and: [ intPart first = $0 ]) ifTrue: [ ^ false ].
+	rest := aString copyFrom: idx to: aString size.
+	rest isEmpty ifTrue: [ ^ true ].
+	rest = '#' ifTrue: [ ^ true ].
+	^ JSONFormatJSONPointer isValidString: rest
+]
+
+{ #category : 'validation' }
+JSONFormatRelativeJSONPointer class >> validateString: aString [
+	(self isValidString: aString) ifFalse: [
+		JSONConstraintError signal: aString printString, ' is not a valid relative-json-pointer' ]
+]

--- a/source/JSONSchema-Core/JSONFormatURI.class.st
+++ b/source/JSONSchema-Core/JSONFormatURI.class.st
@@ -30,7 +30,67 @@ JSONFormatURI class >> validate: aUrl [
 	
 ]
 
+{ #category : 'validation' }
+JSONFormatURI class >> isValidURIAuthority: anAuthority [
+	"authority = [ userinfo @ ] host [ : port ]. Necessary check: after stripping any
+	userinfo, an unbracketed host has at most one colon with a numeric port (so a bare
+	IPv6 without [] is rejected), and a bracketed IP-literal must be closed."
+	| hostport at rest colon |
+	at := anAuthority lastIndexOf: $@.
+	hostport := at = 0 ifTrue: [ anAuthority ] ifFalse: [ anAuthority copyFrom: at + 1 to: anAuthority size ].
+	(hostport notEmpty and: [ hostport first = $[ ]) ifTrue: [
+		| close | close := hostport indexOf: $].
+		close = 0 ifTrue: [ ^ false ].
+		rest := hostport copyFrom: close + 1 to: hostport size.
+		^ rest isEmpty or: [ rest first = $: and: [ rest allButFirst allSatisfy: [ :c | c isDigit ] ] ] ].
+	colon := hostport indexOf: $:.
+	^ colon = 0 or: [ (hostport copyFrom: colon + 1 to: hostport size) allSatisfy: [ :c | c isDigit ] ]
+]
+
+{ #category : 'validation' }
+JSONFormatURI class >> isValidURIScheme: aScheme [
+	"scheme = ALPHA *( ALPHA / DIGIT / + / - / . )"
+	^ aScheme notEmpty
+		and: [ ((aScheme first between: $a and: $z) or: [ aScheme first between: $A and: $Z ])
+		and: [ aScheme allSatisfy: [ :c |
+			(c between: $a and: $z) or: [ (c between: $A and: $Z)
+				or: [ c isDigit or: [ '+-.' includes: c ] ] ] ] ] ]
+]
+
+{ #category : 'validation' }
+JSONFormatURI class >> isValidURIString: aString allowUnicode: allowUnicode [
+	"RFC 3986 URI (RFC 3987 IRI when allowUnicode): a reference carrying a scheme. A
+	necessary structural check - legal characters, a valid scheme, and a well-formed
+	authority when the scheme is followed by //."
+	| colon scheme afterScheme authority rest endIdx |
+	(aString allSatisfy: [ :ch |
+		(self legalURICharacters includes: ch) or: [ allowUnicode and: [ ch asInteger > 127 ] ] ])
+			ifFalse: [ ^ false ].
+	colon := aString indexOf: $:.
+	colon = 0 ifTrue: [ ^ false ].
+	scheme := aString copyFrom: 1 to: colon - 1.
+	(self isValidURIScheme: scheme) ifFalse: [ ^ false ].
+	afterScheme := aString copyFrom: colon + 1 to: aString size.
+	(afterScheme beginsWith: '//') ifFalse: [ ^ true ].
+	rest := afterScheme copyFrom: 3 to: afterScheme size.
+	endIdx := (1 to: rest size) detect: [ :i | '/?#' includes: (rest at: i) ] ifNone: [ rest size + 1 ].
+	authority := rest copyFrom: 1 to: endIdx - 1.
+	^ self isValidURIAuthority: authority
+]
+
+{ #category : 'validation' }
+JSONFormatURI class >> legalURICharacters [
+	"The RFC 3986 character repertoire: unreserved, gen-/sub-delims and the pct marker."
+	^ 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]@!$&''()*+,;=%'
+]
+
+{ #category : 'validation' }
+JSONFormatURI class >> validateString: aString [
+	(self isValidURIString: aString allowUnicode: false) ifFalse: [
+		JSONConstraintError signal: aString printString, ' is not a valid uri' ]
+]
+
 { #category : 'writing' }
-JSONFormatURI class >> write: aZnUrl [ 
+JSONFormatURI class >> write: aZnUrl [
 	^ aZnUrl asString
 ]

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfIRIReferencesTests2.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfIRIReferencesTests2.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'IriReference'
 }
 
-{ #category : 'testing' }
-JSONSchemaValidationOfIRIReferencesTests2 >> expectedFailures [
-	^ #(#testAnInvalidIRIFragment #testAnInvalidIRIReference)
-]
-
 { #category : 'accessing' }
 JSONSchemaValidationOfIRIReferencesTests2 >> schemaString [
 	^ '{"format":"iri-reference"}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfIRIsTests2.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfIRIsTests2.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Iri'
 }
 
-{ #category : 'testing' }
-JSONSchemaValidationOfIRIsTests2 >> expectedFailures [
-	^ #(#testAnInvalidIRI #testAnInvalidIRIBasedOnIPv6 #testAnInvalidIRIThoughValidIRIReference #testAnInvalidRelativeIRIReference)
-]
-
 { #category : 'accessing' }
 JSONSchemaValidationOfIRIsTests2 >> schemaString [
 	^ '{"format":"iri"}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfRelativeJSONPointersRJPTests.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfRelativeJSONPointersRJPTests.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'RelativeJsonPointer'
 }
 
-{ #category : 'testing' }
-JSONSchemaValidationOfRelativeJSONPointersRJPTests >> expectedFailures [
-	^ #(#testAnInvalidRJPThatIsAValidJSONPointer #testNegativePrefix)
-]
-
 { #category : 'accessing' }
 JSONSchemaValidationOfRelativeJSONPointersRJPTests >> schemaString [
 	^ '{"format":"relative-json-pointer"}'

--- a/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfURIsTests2.class.st
+++ b/source/JSONSchema-Testsuite-Tests/JSONSchemaValidationOfURIsTests2.class.st
@@ -6,11 +6,6 @@ Class {
 	#tag : 'Uri'
 }
 
-{ #category : 'testing' }
-JSONSchemaValidationOfURIsTests2 >> expectedFailures [
-	^ #(#testAnInvalidURIWithSpaces #testAnInvalidRelativeURIReference #testAnInvalidProtocolRelativeURIReference #testAnInvalidURIThoughValidURIReference #testAnInvalidURIWithCommaInScheme #testAnInvalidURI #testAnInvalidURIWithSpacesAndMissingScheme)
-]
-
 { #category : 'accessing' }
 JSONSchemaValidationOfURIsTests2 >> schemaString [
 	^ '{"format":"uri"}'


### PR DESCRIPTION
…e-json-pointer

Second, moderate batch of Tier-G format validators, stacked on the cheap-format branch (reuses the generic JSONSchemaFormatConstraint). Turns 15 more previously-expectedFailures format tests green.

  - uri (full)      RFC 3986: existing JSONFormatURI gains a class-side
                    validateString: with a scheme + authority structural check
                    (legal chars, ALPHA-led scheme, at-most-one-colon numeric
                    port so a bare unbracketed IPv6 authority is rejected).
  - iri             JSONFormatIRI subclasses JSONFormatURI and reuses the parser
                    with Unicode (ucschar) allowed.
  - iri-reference   like uri-reference but Unicode allowed (legal-char check).
  - relative-json-pointer  non-negative integer prefix (no leading zeros) then
                    either # or a JSON Pointer (reuses JSONFormatJSONPointer).

Verified: Core 110/110, all four format families green, no regressions (raw runCase sweep drops the testsuite failing set from 141 to 126). expectedFailures cleared in the four now-fully-green test classes (methods deleted per convention).