### PR TITLE
Restore JSONPrimitiveSchema>>nullable: lost in the Filetree->Tonel mi…

### DIFF
--- a/source/JSONSchema-Core/JSONPrimitiveSchema.class.st
+++ b/source/JSONSchema-Core/JSONPrimitiveSchema.class.st
@@ -84,6 +84,11 @@ JSONPrimitiveSchema >> nullable [
 	^ nullable ~~ false
 ]
 
+{ #category : 'accessing' }
+JSONPrimitiveSchema >> nullable: aBoolean [
+	nullable := aBoolean
+]
+
 { #category : 'reading' }
 JSONPrimitiveSchema >> read: anObject [
 	| value |


### PR DESCRIPTION
…gration

The setter existed alongside the getter/ivar in the old Filetree-format history (commit 1d2fd5a) but was dropped when the package was converted to Tonel format. JSONSchemaString/Integer/Number/Boolean callers that set nullable: (as JSONSchemaObject/AnyObject already do via apptive-base extensions) hit a doesNotUnderstand as a result.