### PR TITLE
Add missing definitionProperties to JSONSchemaSingleItemSchemaConstraint

### DIFF
--- a/source/JSONSchema-Core/JSONSchemaSingleItemSchemaConstraint.class.st
+++ b/source/JSONSchema-Core/JSONSchemaSingleItemSchemaConstraint.class.st
@@ -19,6 +19,11 @@ JSONSchemaSingleItemSchemaConstraint >> initializeFromDefinition: aDefinition [
 ]
 
 { #category : 'accessing' }
+JSONSchemaSingleItemSchemaConstraint >> definitionProperties [
+	^ #( items additionalItems )
+]
+
+{ #category : 'accessing' }
 JSONSchemaSingleItemSchemaConstraint >> items [
 	^ items
 ]


### PR DESCRIPTION
Found while round-tripping real OpenAPI 3.0 documents through OpenAPI's document object model (fromString:/specString): the reference-resolve visitor generically introspects each constraint's definitionProperties, but this constraint overrides initializeFromDefinition: directly and never declared it - MessageNotUnderstood on any schema using items/ additionalItems (i.e. any array schema) that goes through that path.